### PR TITLE
Add id prop to text area and input to relate it with the label

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -33,7 +33,8 @@ export const DefaultWithLabel = Template.bind({});
 DefaultWithLabel.args = {
   size: 'large',
   placeholder: 'Enter text',
-  label: 'Input Label'
+  label: 'Input Label',
+  id: 'input-id'
 };
 
 export const PositiveWithLabel = Template.bind({});
@@ -41,7 +42,8 @@ PositiveWithLabel.args = {
   size: 'large',
   state: 'valid',
   placeholder: 'Enter Text',
-  label: 'Input Label'
+  label: 'Input Label',
+  id: 'input-id'
 };
 
 export const NegativeWithLabel = Template.bind({});
@@ -49,5 +51,6 @@ NegativeWithLabel.args = {
   size: 'large',
   state: 'invalid',
   placeholder: 'Enter Text',
-  label: 'Input Label'
+  label: 'Input Label',
+  id: 'input-id'
 };

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -9,12 +9,13 @@ type State = '' | 'valid' | 'invalid';
 interface Props {
   description?: string;
   disabled?: boolean;
+  id: string;
   label?: string;
   message?: string;
   onChange: () => void;
   placeholder?: string;
-  state?: State;
   size: Size;
+  state?: State;
   value?: string;
   variablesClassName?: string;
 }
@@ -23,14 +24,15 @@ const Input: React.FC<Props> = props => {
   const {
     description,
     disabled,
+    id,
     label,
-    onChange,
     message,
+    onChange,
     placeholder,
-    value,
-    variablesClassName,
     size,
     state,
+    value,
+    variablesClassName,
     ...inputProps
   } = props;
   const sizeClass = `input--${size}`;
@@ -42,7 +44,13 @@ const Input: React.FC<Props> = props => {
 
   return (
     <div className={classNames(variablesClassName)}>
-      {label ? <label className={classNames(styles[labelClass])}>{label}</label> : ''}
+      {label ? (
+        <label className={classNames(styles[labelClass])} htmlFor={id}>
+          {label}
+        </label>
+      ) : (
+        ''
+      )}
       {description ? (
         <span className={classNames(styles[descriptionClass])}>{description}</span>
       ) : (
@@ -51,10 +59,11 @@ const Input: React.FC<Props> = props => {
       <input
         {...inputProps}
         className={classNames(styles.input, styles[sizeClass], styles[statusClass])}
+        disabled={disabled}
+        id={id}
         onChange={onChange}
         placeholder={placeholder}
         value={value}
-        disabled={disabled}
       />
       {message ? (
         <span className={classNames(styles[messageClass], styles[messageValidateClass])}>

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -9,12 +9,13 @@ type State = '' | 'valid' | 'invalid';
 interface Props {
   description?: string;
   disabled?: boolean;
+  id: string;
   label?: string;
   message?: string;
   onChange: () => void;
   placeholder?: string;
-  state?: State;
   size: Size;
+  state?: State;
   value?: string;
   variablesClassName?: string;
 }
@@ -23,9 +24,10 @@ const TextArea: React.FC<Props> = props => {
   const {
     description,
     disabled,
+    id,
     label,
-    onChange,
     message,
+    onChange,
     placeholder,
     size,
     state,
@@ -42,7 +44,13 @@ const TextArea: React.FC<Props> = props => {
 
   return (
     <div className={classNames(variablesClassName)}>
-      {label ? <label className={classNames(styles[labelClass])}>{label}</label> : ''}
+      {label ? (
+        <label htmlFor={id} className={classNames(styles[labelClass])}>
+          {label}
+        </label>
+      ) : (
+        ''
+      )}
       {description ? (
         <span className={classNames(styles[descriptionClass])}>{description}</span>
       ) : (
@@ -51,10 +59,11 @@ const TextArea: React.FC<Props> = props => {
       <textarea
         {...textareaProps}
         className={classNames(styles.textarea, styles[sizeClass], styles[statusClass])}
+        disabled={disabled}
+        id={id}
         onChange={onChange}
         placeholder={placeholder}
         value={value}
-        disabled={disabled}
       />
       {message ? (
         <span className={classNames(styles[messageClass], styles[messageValidateClass])}>


### PR DESCRIPTION
If applied, this pull request will add an id prop to the text area and input to relate it with the label

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
N/A


