### PR TITLE
Remove unnecessary bottom border hover effect on list items

### DIFF
--- a/src/components/ListItem/DefaultListItem/DefaultListItem.css
+++ b/src/components/ListItem/DefaultListItem/DefaultListItem.css
@@ -89,7 +89,6 @@
 }
 
 .list-item:hover {
-  border-bottom: var(--list-item-border-hover);
   color: var(--list-item-color-hover);
   font-weight: var(--list-item-font-weight-hover);
 }


### PR DESCRIPTION
If applied, this pull request will Remove unnecessary bottom border hover effect on list items

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
Bug:
![issue](https://user-images.githubusercontent.com/45719240/105416771-68602000-5c19-11eb-9745-3c1cfbfdc2d2.gif)

Solution:
![solution](https://user-images.githubusercontent.com/45719240/105416758-6302d580-5c19-11eb-9814-a38deeec9a40.gif)
