### PR TITLE
Remove unnecessary border-radius from list items

### DIFF
--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -49,7 +49,6 @@
   align-items: center;
   background: var(--list-background-color);
   border: var(--list-border);
-  border-radius: var(--list-border-radius);
   height: 100%;
   justify-content: space-between;
   list-style-type: var(--list-style-type);
@@ -59,7 +58,6 @@
 }
 
 .list--medium {
-  border-radius: var(--list-medium-border-radius);
   font-size: var(--list-medium-font-size);
   font-weight: var(--list-medium-font-weight);
   height: var(--list-medium-height);
@@ -67,7 +65,6 @@
 }
 
 .list--large {
-  border-radius: var(--list-large-border-radius);
   font-size: var(--list-large-font-size);
   font-weight: var(--list-large-font-weight);
   height: var(--list-large-height);
@@ -86,7 +83,6 @@
 .list-item {
   background-color: var(--list-item-background-color);
   border: var(--list-item-border);
-  border-radius: var(--list-item-border-radius);
   box-shadow: var(--list-item-box-shadow);
   box-sizing: var(--list-item-box-sizing);
   margin: var(--list-item-margin);

--- a/src/components/ListItem/CheckMarkListItem/CheckMarkListItem.css
+++ b/src/components/ListItem/CheckMarkListItem/CheckMarkListItem.css
@@ -15,10 +15,6 @@
   --list-item-cm-height--medium: var(--heading-xs);
 }
 
-.list-item-checkmark {
-  border-radius: var(--list-item-cm-border-radius);
-}
-
 .list-item-checkmark--checked {
   fill: var(--list-item-cm-fill-color);
 }

--- a/src/components/ListItem/DefaultListItem/DefaultListItem.css
+++ b/src/components/ListItem/DefaultListItem/DefaultListItem.css
@@ -62,7 +62,6 @@
   align-items: center;
   box-sizing: border-box;
   padding: var(--list-item-padding);
-  border-radius: var(--list-item-border-radius);
   height: 100%;
 }
 


### PR DESCRIPTION
If applied, this pull request will Remove unnecessary border-radius from list items

### Card Link:
N/A

### Design Expected Screenshot
List items of all types do not have a border-radius:
![Screenshot from 2021-01-22 14-19-42](https://user-images.githubusercontent.com/45719240/105523258-f5a88080-5cbc-11eb-8b5d-71050e722417.png)

### Implementation Screenshot or GIF
![Screenshot from 2021-01-22 14-20-34](https://user-images.githubusercontent.com/45719240/105523385-0f49c800-5cbd-11eb-8271-ca7531d962ba.png)
