### PR TITLE
Remove conflicting spread operator from DefaultListItem

### DIFF
--- a/src/components/ListItem/DefaultListItem/index.tsx
+++ b/src/components/ListItem/DefaultListItem/index.tsx
@@ -17,22 +17,12 @@ export interface Props<T> {
 }
 
 const DefaultListItem = <T extends {}>(props: Props<T>) => {
-  const {
-    className,
-    size,
-    getLabel,
-    getIcon,
-    getSelectedMarker,
-    item,
-    variablesClassName,
-    ...listItemProps
-  } = props;
+  const { className, size, getLabel, getIcon, getSelectedMarker, item, variablesClassName } = props;
 
   const sizeSpanClass = `list-item--span-${size}`;
 
   return (
     <div
-      {...listItemProps}
       className={classNames(className, styles['list-item'], variablesClassName)}
       role='button'
       aria-pressed='false'


### PR DESCRIPTION
If applied, this pull request will Remove conflicting spread operator from DefaultListItem

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
Issue:
![Screenshot from 2021-01-28 15-11-54](https://user-images.githubusercontent.com/45719240/106180618-4c113580-617b-11eb-8e6a-8cffbcf97dc1.png)

Solution:
![Peek 2021-01-28 15-13](https://user-images.githubusercontent.com/45719240/106180817-94c8ee80-617b-11eb-8574-604c40818084.gif)

### Notes:
Removes a conflicting case with the spread operator passing unconsumed props from the parent component to the chidl.
