### PR TITLE
Add action icon field

### DIFF
--- a/src/assets/images/icons/web/close-icon.svg
+++ b/src/assets/images/icons/web/close-icon.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L9 9M1 9L9 1" stroke="#898893" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -63,6 +63,13 @@
   --prepend-height: 46px;
   --prepend-height-focus: 44px;
   --prepend-padding: 0 18px;
+
+  --input-action-icon-container-background: transparent;
+  --input-action-icon-margin: 0 20px 0 0;
+  --input-action-icon-cursor: pointer;
+  --input-action-icon-fill: initial;
+  --input-action-icon-fill-hover: initial;
+  --input-action-icon-fill-active: initial;
 }
 
 .container {
@@ -219,4 +226,23 @@
 
 .input.input-with-prepend-separator {
   border-radius: 0 var(--input-large-border-radius) var(--input-large-border-radius) 0;
+}
+
+.input--action-icon-container {
+  background-color: var(--input-action-icon-container-background);
+  cursor: var(--input-action-icon-cursor);
+  margin: var(--input-action-icon-margin);
+  position: absolute;
+}
+
+.input--action-icon {
+  fill: var(--input-action-icon-fill);
+}
+
+.input--action-icon-container:hover > .input--action-icon {
+  fill: var(--input-action-icon-fill-hover);
+}
+
+.input--action-icon-container:active > .input--action-icon {
+  fill: var(--input-action-icon-fill-active);
 }

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import Input from '@/components/Input';
+import TestSearchIcon from '@/assets/images/icons/web/search-simple.svg';
 
 export default {
   title: 'Input',
@@ -51,4 +52,19 @@ WithPrependSeparator.args = {
   label: 'Email',
   validationRegex: '([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\\.[a-zA-Z0-9_-]+)',
   invalidMessage: 'Invalid email'
+};
+
+export const WithDefaultActionIcon = Template.bind({});
+WithDefaultActionIcon.args = {
+  size: 'large',
+  placeholder: 'Enter text',
+  onClickActionIcon: () => alert('default action icon was clicked')
+};
+
+export const WithCustomActionIcon = Template.bind({});
+WithCustomActionIcon.args = {
+  size: 'large',
+  placeholder: 'Enter text',
+  actionIcon: <TestSearchIcon height='10' width='10' />,
+  onClickActionIcon: () => alert('custom action icon was clicked')
 };

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames';
 
 import styles from '@/components/Input/Input.css';
 
+import DefaultActionIcon from '@/assets/images/icons/web/close-icon.svg';
+
 type Size = 'large' | 'medium';
 
 interface Props {
@@ -27,6 +29,8 @@ interface Props {
   limit?: number;
   prepend?: React.ReactNode;
   withPrependSeparator?: boolean;
+  actionIcon?: React.ReactNode;
+  onClickActionIcon: () => void;
 }
 
 const VALID = 'valid';
@@ -61,6 +65,8 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     limit,
     prepend,
     withPrependSeparator,
+    actionIcon,
+    onClickActionIcon,
     ...inputProps
   } = props;
   const [validationState, setValidationState] = useState('');
@@ -71,6 +77,18 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const handleBlur = event => {
     onBlur && onBlur();
     setValidationState(getValidationState(event.target.value, validationRegex, isValid));
+  };
+
+  const getActionIcon = actionIcon => {
+    return actionIcon ? (
+      <>{actionIcon}</>
+    ) : (
+      <DefaultActionIcon
+        className={classNames(styles['input--action-icon'])}
+        height='8'
+        width='8'
+      />
+    );
   };
 
   return (
@@ -121,6 +139,15 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             )}
           >
             {prepend}
+          </div>
+        )}
+
+        {!!onClickActionIcon && (
+          <div
+            className={classNames(styles['input--action-icon-container'])}
+            onClick={onClickActionIcon}
+          >
+            {getActionIcon(actionIcon)}
           </div>
         )}
       </div>


### PR DESCRIPTION
If applied, this pull request will Add action icon field

### Card Link:
N/A

### Design Expected Screenshot
<img width="618" alt="Screen Shot 2021-01-29 at 4 49 39 PM" src="https://user-images.githubusercontent.com/45719240/106513830-3c169000-64b2-11eb-8468-51fc1b744757.png">

### Implementation Screenshot or GIF
![Peek 2021-02-01 17-22](https://user-images.githubusercontent.com/45719240/106513847-4173da80-64b2-11eb-93b1-bd6d9642bc8d.gif)

### Notes:
The component should show a default action icon (x) if one isn't specified. If a onClickActionIcon function isn't passed as a param, the actionIcon should not appear.
