### PR TITLE
Add action icon to address search input

### DIFF
--- a/src/components/AddressSearchInput/index.tsx
+++ b/src/components/AddressSearchInput/index.tsx
@@ -18,6 +18,7 @@ interface Props {
 const AddressSearchInput: React.FC<Props> = props => {
   const { value, onChange, inputId, dropdownId, placeholder, variablesClassName } = props;
   const [initialValue, setInitialValue] = useState(value);
+  const [clearable, setClearable] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [{ height }, setInputPosition] = useState({ height: 0 });
@@ -54,6 +55,10 @@ const AddressSearchInput: React.FC<Props> = props => {
   useEffect(() => {
     setInitialValue(value);
   }, [value]);
+
+  useEffect(() => {
+    initialValue.length > 0 ? setClearable(true) : handleClearInput();
+  }, [initialValue]);
 
   useEffect(() => {
     if (isSuggestionListOpen && listRef && listRef.current) {
@@ -101,6 +106,11 @@ const AddressSearchInput: React.FC<Props> = props => {
     }
   };
 
+  const handleClearInput = () => {
+    setInitialValue('');
+    setClearable(false);
+  };
+
   const renderSuggestions = () => (
     <List<google.maps.places.AutocompletePrediction>
       ref={listRef}
@@ -135,6 +145,8 @@ const AddressSearchInput: React.FC<Props> = props => {
         onMouseLeave={() => setIsInputHovered(false)}
         disabled={loading}
         variablesClassName={classnames(styles['address-search-input'])}
+        withActionIcon={clearable}
+        onClickActionIcon={handleClearInput}
       />
       {isSuggestionListOpen && renderSuggestions()}
     </div>


### PR DESCRIPTION
If applied, this pull request will Add action icon to address search input

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Peek 2021-02-02 17-31](https://user-images.githubusercontent.com/45719240/106658790-849a8000-657c-11eb-99bf-07e956cdf066.gif)

### Notes:
The actionIcon should only appear if text has been inputted in the field. If there is no text, it should disappear.
