### PR TITLE
Update the conditional render logic for input action icon

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -58,6 +58,7 @@ export const WithDefaultActionIcon = Template.bind({});
 WithDefaultActionIcon.args = {
   size: 'large',
   placeholder: 'Enter text',
+  withActionIcon: true,
   onClickActionIcon: () => alert('default action icon was clicked')
 };
 
@@ -66,5 +67,6 @@ WithCustomActionIcon.args = {
   size: 'large',
   placeholder: 'Enter text',
   actionIcon: <TestSearchIcon height='10' width='10' />,
+  withActionIcon: true,
   onClickActionIcon: () => alert('custom action icon was clicked')
 };

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   prepend?: React.ReactNode;
   withPrependSeparator?: boolean;
   actionIcon?: React.ReactNode;
+  withActionIcon?: boolean;
   onClickActionIcon: () => void;
 }
 
@@ -66,6 +67,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     prepend,
     withPrependSeparator,
     actionIcon,
+    withActionIcon,
     onClickActionIcon,
     ...inputProps
   } = props;
@@ -142,7 +144,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           </div>
         )}
 
-        {!!onClickActionIcon && (
+        {withActionIcon && (
           <div
             className={classNames(styles['input--action-icon-container'])}
             onClick={onClickActionIcon}


### PR DESCRIPTION
If applied, this pull request will Update the conditional render logic for input action icon

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Peek 2021-02-01 17-22](https://user-images.githubusercontent.com/45719240/106651647-38970d80-6573-11eb-87a3-26eb601a2a28.gif)

### Notes:
If a property of withActionIcon is passed a value of false or is omitted, the action icon will not appear. The action icon only appears with a value of true.
