### PR TITLE
Add TextArea component documentation

### DIFF
--- a/src/components/TextArea/TextArea.css
+++ b/src/components/TextArea/TextArea.css
@@ -10,9 +10,10 @@
   background-color: var(--textarea-background-color);
   box-sizing: border-box;
   color: var(--textarea-color, var(--structure-color-900));
-  width: 100%;
   display: flex;
+  margin: var(--textarea-margin, 0);
   resize: none;
+  width: var(--textarea-width, 100%);
 }
 
 .textarea:active {
@@ -93,17 +94,17 @@
 }
 
 .textarea--message-valid {
-  color: var(--textarea-message-positive-color, var(--success-color));
+  color: var(--textarea-message-color-valid, var(--success-color));
 }
 
 .textarea--message-invalid {
-  color: var(--textarea-message-negative-color, var(--error-color));
+  color: var(--textarea-message-color-invalid, var(--error-color));
 }
 
 .textarea.textarea--valid {
-  border: var(--textarea-border-positive, 1px solid var(--success-color));
+  border: var(--textarea-border-valid, 1px solid var(--success-color));
 }
 
 .textarea.textarea--invalid {
-  border: var(--textarea-border-negative, 1px solid var(--error-color));
+  border: var(--textarea-border-invalid, 1px solid var(--error-color));
 }

--- a/src/components/TextArea/TextArea.stories.mdx
+++ b/src/components/TextArea/TextArea.stories.mdx
@@ -1,0 +1,118 @@
+# TextArea Component
+
+## TextArea Props
+
+|        Prop        |    Type    | Default | Optional |
+| :----------------: | :--------: | :-----: | :------: |
+|    description     |   string   |    -    |   true   |
+|      disabled      |  boolean   |    -    |   true   |
+|         id         |   string   |    -    |  false   |
+|       label        |   string   |    -    |   true   |
+|      message       |   string   |    -    |   true   |
+|      onChange      | () => void |    -    |  false   |
+|    placeholder     |   string   |    -    |   true   |
+|        size        |    Size    |  large  |   true   |
+|       state        |   State    |    -    |   true   |
+|       value        |   string   |    -    |  false   |
+| variablesClassName |   string   |    -    |   true   |
+
+**States availables:**
+
+1. [default:('')](https://design-system.codelitt.dev/?path=/story/components-text-area--default)
+2. [valid](https://design-system.codelitt.dev/?path=/story/components-text-area--positive)
+3. [invalid](https://design-system.codelitt.dev/?path=/story/components-text-area--negative)
+
+**Sizes**
+
+1. large
+2. medium
+
+## Getting Started
+
+```javascript
+import React, { Component, useState } from 'react';
+import { TextArea } from '@codelittinc/agnostic-design-system';
+
+class SimpleTextArea extends Component {
+  const [value, setValue] = useState('');
+
+  const handleChange = (e) => {
+    setValue(e.target.value);
+  }
+
+  render() {
+    return (
+      <TextArea onChange={handleChange} value={value} label='Simple TextArea' placeholder='Enter Text' />
+    );
+  }
+}
+
+export default SimpleTextArea;
+
+```
+
+# Customazing styles
+
+For the [TextArea](https://design-system.codelitt.dev/?path=/story/components-text-area--default) component we use the following [naming convention](https://design-system.codelitt.dev/?path=/story/welcome-customizing-styles--page) to configure the CSS variables:
+
+**--textarea-[property]?-[attribute]-[state]?**
+
+- Property - description, label, message, placeholder (optional)
+- Attribute - background-color, border, font, etc (required)
+- State - hover, focus, active, disabled, valid, invalid (optional)
+
+1. Create the css class using our variables
+
+```css
+.my-textarea-css {
+  /* Component + Attribute */
+  --textarea-border-color: 1px solid grey;
+
+  /* Component + Property + Attribute */
+  --textarea-message-color: black;
+
+  /* Component + Property + Attribute */
+  --textarea-description-font-size: 20px;
+
+  /* Component + Property + Attribute + State */
+  --textarea-message-color-valid: green;
+}
+```
+
+2. Pass the css class through its `variablesClassName` property
+
+`<TextArea variablesClassName={styles['my-textarea-css']} />`
+
+# Variables available
+
+|  Property   |    Attribute     |                     State                      |
+| :---------: | :--------------: | :--------------------------------------------: |
+|             | background-color |         hover, focus, active, disabled         |
+|             |      border      | hover, focus, active, disabled, valid, invalid |
+|             |  border-radius   |                                                |
+|             |      color       |                                                |
+|             |    font-size     |                                                |
+|             |   font-weight    |                                                |
+|             |      height      |                                                |
+|             |   line-height    |                                                |
+|             |      margin      |                                                |
+|             |     padding      |                                                |
+|             |      width       |                                                |
+| description |      color       |                                                |
+| description |    font-size     |                                                |
+| description |   font-weight    |                                                |
+| description |   line-height    |                                                |
+| description |      height      |                                                |
+|    label    |      color       |                                                |
+|    label    |    font-size     |                                                |
+|    label    |   font-weight    |                                                |
+|    label    |   line-height    |                                                |
+|    label    |      height      |                                                |
+|   message   |      color       |                 valid, invalid                 |
+|   message   |    font-size     |                                                |
+|   message   |   font-weight    |                                                |
+|   message   |   line-height    |                                                |
+|   message   |      height      |                                                |
+| placeholder |      color       |                                                |
+| placeholder |    font-size     |                                                |
+| placeholder |   font-weight    |                                                |

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import TextArea from '@/components/TextArea';
+import mdx from './TextArea.stories.mdx';
 
 export default {
-  title: 'Components/Text Area',
-  component: TextArea
+  title: 'Components/TextArea',
+  component: TextArea,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
 } as Meta;
 
 const Template = args => <TextArea {...args} />;

--- a/src/components/Toast/Toast.stories.mdx
+++ b/src/components/Toast/Toast.stories.mdx
@@ -98,7 +98,7 @@ For the Toast component we use the following [naming convention](https://design-
   /* Component + Attribute */
   --toast-background-color: blue;
 
-  /* Component + Property + Attribute + State */
+  /* Component + Property + Attribute */
   --toast-icon-color: red;
 
   /* Component + Property + Attribute */


### PR DESCRIPTION
If applied, this pull request will add the TextArea component documentation

### Other minor changes:
 - Fixed Toast documentation

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Seleção_358](https://user-images.githubusercontent.com/12198683/108864316-d741e780-75d0-11eb-8e4f-9c0ba619f20d.png)
![Seleção_359](https://user-images.githubusercontent.com/12198683/108864323-d90bab00-75d0-11eb-9c62-3015cfc0e934.png)
![Seleção_362](https://user-images.githubusercontent.com/12198683/108864686-330c7080-75d1-11eb-8c87-b35954063c55.png)
![Seleção_363](https://user-images.githubusercontent.com/12198683/108864693-356eca80-75d1-11eb-9c02-70f54de489b0.png)

### Notes:
N/A
