### PR TITLE
Update input prepend height css definition

### DIFF
--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -96,7 +96,14 @@
   );
   border: var(--input-border-focus, var(--input-border));
   border-right: none;
-  height: var(--input-prepend-height-focus, 44px);
+}
+
+.input:focus + .input--prepend.input--prepend-with-separator-large {
+  height: calc(var(--input-height, var(--height-l)) - 4px);
+}
+
+.input:focus + .input--prepend.input--prepend-with-separator-medium {
+  height: calc(var(--input-height, var(--height-m)) - 4px);
 }
 
 .input::placeholder {
@@ -194,10 +201,17 @@
   border-radius: var(--input-border-radius, var(--round-m)) 0 0
     var(--input-border-radius, var(--round-m));
   border-right: none;
-  height: var(--input-prepend-height, 46px);
   left: 0;
   padding: var(--input-prepend-padding, 0 18px);
   width: auto;
+}
+
+.input--prepend.input--prepend-with-separator-large {
+  height: calc(var(--input-height, var(--height-l)) - 2px);
+}
+
+.input--prepend.input--prepend-with-separator-medium {
+  height: calc(var(--input-height, var(--height-m)) - 2px);
 }
 
 .input.input--large.input-with-prepend {

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -149,7 +149,6 @@ For the [Input](https://design-system.codelitt.dev/?path=/story/components-input
 | placeholder |    font-size     |                                                    |
 | placeholder |   font-weight    |                                                    |
 |   prepend   | background-color |             hover, positive, negative              |
-|   prepend   |      height      |                                                    |
 |   prepend   |       left       |                                                    |
 |   prepend   |     padding      |                                                    |
 |   prepend   |   padding-left   |                                                    |

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -76,6 +76,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   } = props;
   const [validationState, setValidationState] = useState('');
   const sizeClass = `input--${size}`;
+  const prependSizeClass = `input--prepend-with-separator-${size}`;
   const messageValidateClass = `input--message-${validationState}`;
   const statusClass = `input--${validationState}`;
 
@@ -163,6 +164,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           <div
             className={classNames(
               styles['input--prepend'],
+              withPrependSeparator ? styles[prependSizeClass] : '',
               withPrependSeparator ? styles['input--prepend-with-separator'] : ''
             )}
           >


### PR DESCRIPTION
If applied, this pull request will Update input prepend height css definition

### Card Link:
https://codelitt.atlassian.net/browse/ADS-18

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Peek 2021-03-08 16-26](https://user-images.githubusercontent.com/45719240/110370983-235a4680-802b-11eb-8faf-b734d020550e.gif)
![Peek 2021-03-08 16-26-2](https://user-images.githubusercontent.com/45719240/110370988-23f2dd00-802b-11eb-8f51-ed75cc6a4ac7.gif)

### Notes
Removed the input-prepend-height variable to have the element's height be tied to the base input CSS. Calc is being used as a solution to bridge the gap in the differences between state.