### PR TITLE
Remove State property from TextArea component

### DIFF
--- a/src/components/TextArea/TextArea.stories.mdx
+++ b/src/components/TextArea/TextArea.stories.mdx
@@ -2,27 +2,27 @@
 
 ## TextArea Props
 
-|        Prop        |       Type       | Default | Optional |
-| :----------------: | :--------------: | :-----: | :------: |
-|    description     |      string      |    -    |   true   |
-|      disabled      |     boolean      |    -    |   true   |
-|         id         |      string      |    -    |  false   |
-|       label        |      string      |    -    |   true   |
-|      message       |      string      |    -    |   true   |
-|       onBlur       |    () => void    |    -    |   true   |
-|      onChange      | (e: any) => void |    -    |  false   |
-|    placeholder     |      string      |    -    |   true   |
-|      required      |     boolean      |    -    |   true   |
-|        size        |       Size       |  large  |   true   |
-|       state        |      State       |    -    |   true   |
-|       value        |      string      |    -    |  false   |
-| variablesClassName |      string      |    -    |   true   |
+|        Prop        |           Type           | Default | Optional |
+| :----------------: | :----------------------: | :-----: | :------: |
+|    description     |          string          |    -    |   true   |
+|      disabled      |         boolean          |    -    |   true   |
+|         id         |          string          |    -    |  false   |
+|       label        |          string          |    -    |   true   |
+|      message       |          string          |    -    |   true   |
+|       onBlur       |        () => void        |    -    |   true   |
+|      onChange      |     (e: any) => void     |    -    |  false   |
+|   onStateChange    | (state: boolean) => void |    -    |   true   |
+|    placeholder     |          string          |    -    |   true   |
+|      required      |         boolean          |    -    |   true   |
+|        size        |           Size           |  large  |   true   |
+|       value        |          string          |    -    |  false   |
+| variablesClassName |          string          |    -    |   true   |
 
-**States availables:**
+**Props**
 
-1. [default:('')](https://design-system.codelitt.dev/?path=/story/components-text-area--default)
-2. [valid](https://design-system.codelitt.dev/?path=/story/components-text-area--positive)
-3. [invalid](https://design-system.codelitt.dev/?path=/story/components-text-area--negative)
+|     Property      | Description                                                             |
+| :---------------: | :---------------------------------------------------------------------- |
+| **onStateChange** | It returns a boolean on **onChange** event when **required** be applied |
 
 **Sizes**
 

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -20,18 +20,6 @@ Default.args = {
   placeholder: 'Enter Text'
 };
 
-export const Positive = Template.bind({});
-Positive.args = {
-  state: 'valid',
-  placeholder: 'Enter Text'
-};
-
-export const Negative = Template.bind({});
-Negative.args = {
-  state: 'invalid',
-  placeholder: 'Enter Text'
-};
-
 export const RequiredTextArea = Template.bind({});
 RequiredTextArea.args = {
   required: true,
@@ -41,19 +29,11 @@ RequiredTextArea.args = {
 export const DefaultWithLabel = Template.bind({});
 DefaultWithLabel.args = {
   placeholder: 'Enter text',
-  label: 'Input Label'
+  label: 'TextArea Label'
 };
 
-export const PositiveWithLabel = Template.bind({});
-PositiveWithLabel.args = {
-  state: 'valid',
-  placeholder: 'Enter Text',
-  label: 'Input Label'
-};
-
-export const NegativeWithLabel = Template.bind({});
-NegativeWithLabel.args = {
-  state: 'invalid',
-  placeholder: 'Enter Text',
-  label: 'Input Label'
+export const DefaultWithMessage = Template.bind({});
+DefaultWithMessage.args = {
+  placeholder: 'Enter text',
+  message: 'TextArea Message'
 };

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 
 import styles from '@/components/TextArea/TextArea.css';
 
 type Size = 'large' | 'medium';
-type State = '' | 'valid' | 'invalid';
 
 interface Props {
   description?: string;
@@ -14,13 +13,16 @@ interface Props {
   message?: string;
   onBlur?: () => void;
   onChange: (e: any) => void;
+  onStateChange: (state: boolean) => void;
   placeholder?: string;
   size: Size;
-  state?: State;
   value?: string;
   variablesClassName?: string;
   required?: boolean;
 }
+
+const VALID = 'valid';
+const INVALID = 'invalid';
 
 const TextArea: React.FC<Props> = props => {
   const {
@@ -31,15 +33,16 @@ const TextArea: React.FC<Props> = props => {
     message,
     onBlur,
     onChange,
+    onStateChange,
     placeholder,
     size,
-    state,
     value,
     variablesClassName,
     required,
     ...textareaProps
   } = props;
-  const [stateTextArea, setStateTextArea] = useState(state);
+  const [stateTextArea, setStateTextArea] = useState('');
+  const [stateChange, setStateChange] = useState(true);
   const sizeClass = `textarea--${size}`;
   const messageClass = 'textarea--message';
   const messageValidateClass = stateTextArea !== '' ? `textarea--message-${stateTextArea}` : '';
@@ -47,18 +50,20 @@ const TextArea: React.FC<Props> = props => {
   const descriptionClass = 'textarea--description';
   const labelClass = 'textarea--label';
 
-  const validateRequired = value => {
-    const regex = new RegExp('.+');
-    return value.match(regex);
-  };
+  const validateRequired = value => value.match(new RegExp('.+'));
 
   const handleRequired = value => {
-    validateRequired(value) ? setStateTextArea('valid') : setStateTextArea('invalid');
+    validateRequired(value) ? setStateTextArea(VALID) : setStateTextArea(INVALID);
   };
+
+  useEffect(() => {
+    required && setStateChange(stateTextArea === VALID);
+  }, [stateTextArea]);
 
   const handleOnChange = e => {
     onChange(e);
     required && handleRequired(e.target.value);
+    onStateChange(stateChange);
   };
 
   const handleOnBlur = e => {
@@ -103,7 +108,7 @@ const TextArea: React.FC<Props> = props => {
 
 TextArea.defaultProps = {
   size: 'large',
-  state: ''
+  onStateChange: state => state
 };
 
 export default TextArea;


### PR DESCRIPTION
If applied, this pull request will remove the State property from the Textarea component

### Other minor changes:
 N/A

### Card Link:
https://codelitt.atlassian.net/browse/ADS-32

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
Default 
![Peek 15-03-2021 18-00](https://user-images.githubusercontent.com/12198683/111220766-5b780100-85b8-11eb-907c-08e5fbbb9e14.gif)

Using required
![Peek 15-03-2021 17-59](https://user-images.githubusercontent.com/12198683/111220674-3edbc900-85b8-11eb-81c0-2dd41471193c.gif)


### Notes:
N/A
