### PR TITLE
Feature/add get content to buttn

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -5,6 +5,7 @@
 |        Prop        |      Type       | Default | Optional |
 | :----------------: | :-------------: | :-----: | :------: |
 |     appendIcon     | React.ReactNode |    -    |   true   |
+|      content       | React.ReactNode |    -    |   true   |
 |      disabled      |     boolean     |  false  |   true   |
 |       label        |     string      |    -    |   true   |
 |      category      |    Category     | neutral |   true   |

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -72,3 +72,14 @@ WithoutLabelWithAppendIcon.args = {
   category: 'primary',
   withAppendIcon: true
 };
+
+export const WithCustomContent = Template.bind({});
+WithCustomContent.args = {
+  category: 'secondary',
+  content: (
+    <div>
+      <TestSearchIcon />
+      <div>Text</div>
+    </div>
+  )
+};

--- a/src/components/Button/DefaultButton/index.tsx
+++ b/src/components/Button/DefaultButton/index.tsx
@@ -4,14 +4,15 @@ import styles from '@/components/Button/DefaultButton/DefaultButton.css';
 import DefaultAppendIcon from '@/assets/images/icons/web/append-button-icon.svg';
 
 interface Props {
+  appendIcon?: React.ReactNode;
   className: string;
+  content?: React.ReactNode;
   disabled?: boolean;
   fixed?: boolean;
   label?: string;
   onClick: () => void;
   size?: string;
   variablesClassName?: string;
-  appendIcon?: React.ReactNode;
   withAppendIcon?: boolean;
 }
 
@@ -20,17 +21,15 @@ const getAppendIcon = (appendIcon, size) => {
   const sizeWidthIcon = largeIcon ? 8 : 6;
   const sizeHeightIcon = largeIcon ? 14 : 10;
 
-  return (
-    appendIcon ? (
-      <>{appendIcon}</>
-    ) : (
-        <DefaultAppendIcon
-          className={classNames(styles['button--append-icon'])}
-          height={sizeHeightIcon}
-          width={sizeWidthIcon}
-        />
-      )
-  )
+  return appendIcon ? (
+    <>{appendIcon}</>
+  ) : (
+    <DefaultAppendIcon
+      className={classNames(styles['button--append-icon'])}
+      height={sizeHeightIcon}
+      width={sizeWidthIcon}
+    />
+  );
 };
 
 const getButtonContent = (label, withAppendIcon, appendIcon, size) => {
@@ -44,8 +43,8 @@ const getButtonContent = (label, withAppendIcon, appendIcon, size) => {
         </div>
       )}
     </>
-  )
-}
+  );
+};
 
 const DefaultButton: React.FC<Props> = props => {
   const {
@@ -57,11 +56,13 @@ const DefaultButton: React.FC<Props> = props => {
     variablesClassName,
     appendIcon,
     withAppendIcon,
+    content,
     ...buttonProps
   } = props;
 
   const sizeClass = `button--${size}`;
 
+  const buttonContent = content || getButtonContent(label, withAppendIcon, appendIcon, size);
   return (
     <button
       {...buttonProps}
@@ -77,7 +78,7 @@ const DefaultButton: React.FC<Props> = props => {
         variablesClassName
       )}
     >
-      {getButtonContent(label, withAppendIcon, appendIcon, size)}
+      {buttonContent}
     </button>
   );
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -11,14 +11,15 @@ type Category = 'ghost' | 'negative' | 'neutral' | 'positive' | 'primary' | 'sec
 type Size = 'large' | 'medium';
 
 interface Props {
-  disabled?: boolean;
-  label?: string;
+  appendIcon?: React.ReactNode;
   category?: Category;
+  content?: React.ReactNode;
+  disabled?: boolean;
   fixed?: boolean;
+  label?: string;
   onClick: () => void;
   size?: Size;
   variablesClassName?: string;
-  appendIcon?: React.ReactNode;
   withAppendIcon?: boolean;
 }
 


### PR DESCRIPTION
If applied, this pull request will add the property "Content" to the button component

### Other minor changes:
 - refactor the button component to improve the code

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
<img width="125" alt="Screen Shot 2021-03-16 at 8 46 09 AM" src="https://user-images.githubusercontent.com/1529246/111304096-15608300-8634-11eb-87bf-b19ae3276830.png">


### Notes:
Now we can pass any content to a button
