### PR TITLE
Update dropdown story examples

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -41,11 +41,35 @@ DefaultDropdown.args = {
   getListTitle: item => item.label
 };
 
+export const DisabledDropdown = Template.bind({});
+DisabledDropdown.args = {
+  category: 'simple',
+  id: 'ads-dropdown',
+  size: 'large',
+  label: 'Dropdown',
+  options: [
+    {
+      label: 'Option 1',
+      value: '1'
+    },
+    {
+      label: 'Option 2',
+      value: '2'
+    }
+  ],
+  getItemLabel: item => item.label,
+  getItemKey: item => item.value,
+  getItemValue: item => item.value,
+  getListTitle: item => item.label,
+  disabled: true
+};
+
 export const EditableDropdown = Template.bind({});
 EditableDropdown.args = {
   category: 'simple',
   id: 'ads-dropdown',
   size: 'large',
+  label: "Editable Dropdown with 'Option 2' initially selected",
   selected: {
     label: 'Option 2',
     value: '2'
@@ -73,6 +97,7 @@ IconDropdown.args = {
   category: 'icon',
   size: 'large',
   listItemCategory: 'simple',
+  label: "Editable Icon Dropdown with 'Option 2' initially selected",
   selected: {
     label: 'Option 2',
     value: '2'
@@ -116,4 +141,41 @@ CheckBoxDropdown.args = {
   getItemValue: item => item.value,
   getListTitle: () => 'Dropdown',
   multiselect: true
+};
+
+export const FilteredOptionsDropdown = Template.bind({});
+FilteredOptionsDropdown.args = {
+  id: 'ads-dropdown',
+  category: 'simple',
+  size: 'large',
+  listItemCategory: 'simple',
+  label: "Dropdown filtered to only render options containing the string 'Foo'",
+  placeholder: 'Select an option',
+  options: [
+    {
+      label: 'Foo',
+      value: '1'
+    },
+    {
+      label: 'Bar',
+      value: '2'
+    },
+    {
+      label: 'Foo Bar',
+      value: '3'
+    },
+    {
+      label: 'Foo Foo',
+      value: '4'
+    },
+    {
+      label: 'Bar Bar',
+      value: '5'
+    }
+  ],
+  editable: true,
+  getItemLabel: item => item.label,
+  getItemKey: item => item.value,
+  getItemValue: item => item.value,
+  filterOptions: options => options.filter(option => option.label.includes('Foo'))
 };


### PR DESCRIPTION
If applied, this pull request will Update dropdown story examples

### Card Link:
https://codelitt.atlassian.net/browse/ADS-81

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Screenshot from 2021-04-07 14-21-59](https://user-images.githubusercontent.com/45719240/113908400-e2318f80-97ac-11eb-897a-1264f7dcc37d.png)

![Screenshot from 2021-04-07 14-22-05](https://user-images.githubusercontent.com/45719240/113908405-e2ca2600-97ac-11eb-87c5-f236cdf681e2.png)

### Notes:
Improves current examples to be more descriptive and adds other examples (disabled dropdown and filteredOptions)
