### PR TITLE
Straighten out border radius of Dropdown when opened

### DIFF
--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -36,10 +36,14 @@
   --input-width: var(--dropdown-width, 100%);
 }
 
+.dropdown-input:not(:only-child) {
+  --input-border-radius: var(--round-m) var(--round-m) 0 0;
+}
+
 .dropdown-list {
   --list-background-color: var(--structure-color-white);
   --list-border: 1px solid var(--primary-color-200);
-  --list-border-radius: var(--round-m);
+  --list-border-radius: 0 0 var(--round-m) var(--round-m);
   --list-box-shadow: none;
   --list-height: auto;
   --list-margin: 0;
@@ -82,6 +86,10 @@
   --button-justify-content: space-between;
   --button-padding: 5px 10px;
   --button-width: var(--dropdown-width, 100%);
+}
+
+.dropdown-button:not(:only-child) {
+  --button-border-radius: var(--round-m) var(--round-m) 0 0;
 }
 
 .dropdown-prepend-icon {


### PR DESCRIPTION
If applied, this pull request will Straighten out border radius of Dropdown when opened

### Card Link:
https://codelitt.atlassian.net/browse/ADS-86

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Peek 2021-04-09 17-16](https://user-images.githubusercontent.com/45719240/114236001-5b6ce600-9957-11eb-8914-fcf22424999f.gif)
![Peek 2021-04-09 17-17](https://user-images.githubusercontent.com/45719240/114236094-7b9ca500-9957-11eb-8293-6aaf5fdde10e.gif)
