### PR TITLE
Add no-console rule to ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
       {
           "varsIgnorePattern": "^Meta$"
       }
-    ]
+    ],
+    "no-console": "error"
   }
 }


### PR DESCRIPTION
If applied, this pull request will trigger an ESLint error every time a console.log is used.

### Card Link:
Resolves #201 
