### PR TITLE
Create Range Slider component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7592,8 +7592,7 @@
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -9405,6 +9404,11 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
       "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
       "dev": true
+    },
+    "dom-align": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
+      "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -19824,6 +19828,78 @@
         }
       }
     },
+    "rc-align": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.9.tgz",
+      "integrity": "sha512-myAM2R4qoB6LqBul0leaqY8gFaiECDJ3MtQDmzDo9xM9NRT/04TvWOYd2YHU9zvGzqk9QXF6S9/MifzSKDZeMw==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "dom-align": "^1.7.0",
+        "rc-util": "^5.3.0",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "rc-motion": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.4.tgz",
+      "integrity": "sha512-ms7n1+/TZQBS0Ydd2Q5P4+wJTSOrhIrwNxLXCZpR7Fa3/oac7Yi803HDALc2hLAKaCTQtw9LmQeB58zcwOsqlQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.2.1"
+      }
+    },
+    "rc-slider": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.7.2.tgz",
+      "integrity": "sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-tooltip": "^5.0.1",
+        "rc-util": "^5.0.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
+    "rc-tooltip": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.1.tgz",
+      "integrity": "sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "rc-trigger": "^5.0.0"
+      }
+    },
+    "rc-trigger": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.9.tgz",
+      "integrity": "sha512-0Bxsh2Xe+etejMn73am+jZBcOpsueAZiEKLiGoDfA0fvm/JHLNOiiww3zJ0qgyPOTmbYxhsxFcGOZu+VcbaZhQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-align": "^4.0.0",
+        "rc-motion": "^2.0.0",
+        "rc-util": "^5.5.0"
+      }
+    },
+    "rc-util": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.13.1.tgz",
+      "integrity": "sha512-Dws2tjXBBihfjVQFlG5JzZ/5O3Wutctm0W94Wb1+M7GD2roWJPrQdSa4AkWm2pn0Ms32zoVPPkWodFeAYZPLfA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "react": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
@@ -22269,6 +22345,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -23130,8 +23211,7 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "dependencies": {
     "downshift": "^6.1.0",
     "jest-svg-transformer": "^1.0.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "rc-slider": "^9.7.2"
   }
 }

--- a/src/components/RangeSlider/RangeSlider.css
+++ b/src/components/RangeSlider/RangeSlider.css
@@ -1,0 +1,7 @@
+@import '../../styles/theme/index.css';
+
+.range-slider-container {
+  font-family: var(--range-slider-font-family, 'Inter');
+  margin: var(--range-slider-margin, 50px);
+  width: var(--range-slider-width, 600px);
+}

--- a/src/components/RangeSlider/RangeSlider.stories.css
+++ b/src/components/RangeSlider/RangeSlider.stories.css
@@ -1,0 +1,23 @@
+.range-marker {
+  border-left: 0.0625rem solid var(--primary-color-300);
+  height: 0.75rem;
+  margin-top: 0.5625rem;
+}
+.range-marker-container {
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: flex-start;
+  height: 4.875rem;
+  font-size: 1rem;
+  color: var(--primary-color-700);
+  font-weight: 700;
+}
+.range-marker-container .range-marker {
+  border-left: 0.0625rem solid var(--primary-color-300);
+  height: 1rem;
+  margin-top: 0.5625rem;
+}
+.range-marker-container .range-marker-highlight {
+  border-left: 0.0625rem solid var(--primary-color-700);
+}

--- a/src/components/RangeSlider/RangeSlider.stories.mdx
+++ b/src/components/RangeSlider/RangeSlider.stories.mdx
@@ -1,0 +1,67 @@
+# Range Slider Component
+
+## Type: Simple
+
+## Range Slider Props
+
+OBS: An asterisk (\*) denotes that the property will have additional info below the table.
+
+|        Prop        |             Type              |                                                                                                                Description                                                                                                                | Default | Mandatory |
+| :----------------: | :---------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :-------: |
+|      disabled      |            boolean            |                                                                                          Specifies whether or not the Slider should be disabled.                                                                                          |    -    |   false   |
+|      dotStyle      |            Object             |                                                                                                        The style used for the dot.                                                                                                        |    -    |   false   |
+|       handle       | (props) => React.ReactElement |                                                                                               An element that replaces the default handle.                                                                                                |    -    |   false   |
+|    handleStyle     |      React.CSSProperties      |                                                                                                      The style used for the handle.                                                                                                       |    -    |   false   |
+|       label        |            string             |                                                                                                     Text displayed above the Slider.                                                                                                      |    -    |   false   |
+|       marks        |              T[]              |                                                             Marks on the slider. The key determines the position, and the value determines the element that will be rendered.                                                             |    -    |   false   |
+|        max         |            number             |                                                                                                           Range maximum value.                                                                                                            |    -    |   false   |
+|        min         |            number             |                                                                                                           Range minimum value.                                                                                                            |    -    |   false   |
+|      onChange      |    (value: number) => void    |                                                                                       Calls a function whenever the value of the Slider is changed.                                                                                       |    -    |   false   |
+|     railStyle      |      React.CSSProperties      |                                                                                                 The style used for the track base color.                                                                                                  |    -    |   false   |
+|        step        |            number             | Value to be added or subtracted on each step the slider makes. Must be greater than zero, and max - min should be evenly divisible by the step value. When marks is not an empty object, step can be set to null, to make marks as steps. |    -    |   false   |
+|     trackStyle     |      React.CSSProperties      |                                                                                                       The style used for the track.                                                                                                       |    -    |   false   |
+|       value        |            string             |                                                                                                         The value of the Slider.                                                                                                          |    -    |   false   |
+| variablesClassName |            string             |                                                                                                      Accepts custom CSS class names.                                                                                                      |    -    |   false   |
+
+## Getting Started
+
+```javascript
+import React, { Component } from 'react';
+import { RangeSlider } from '@codelittinc/agnostic-design-system';
+
+class SimpleRangeSlider extends Component {
+  state = { value: 0 };
+
+  render() {
+    return (
+      <RangeSlider
+        value={this.state.value}
+        onChange={value => this.setState({ ...this.state, value: value })}
+      />
+    );
+  }
+}
+
+export default SimpleRangeSlider;
+```
+
+## CSS Variables available
+
+| Property |    Attribute     | State |
+| :------: | :--------------: | :---: |
+|          |   font-family    |       |
+|          |      margin      |       |
+|          |      width       |       |
+|  handle  | background-color |       |
+|  handle  |      border      |       |
+|  handle  |  border-radius   |       |
+|  handle  |    box-shadow    |       |
+|  handle  |      height      |       |
+|  handle  |    margin-top    |       |
+|  handle  |      width       |       |
+|   rail   | background-color |       |
+|   rail   |  border-radius   |       |
+|   rail   |      height      |       |
+|  track   | background-color |       |
+|  track   |  border-radius   |       |
+|  track   |      height      |       |

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import RangeSlider from '@/components/RangeSlider';
+import styles from './RangeSlider.stories.css';
+import { Meta } from '@storybook/react';
+import mdx from './RangeSlider.stories.mdx';
+
+export default {
+  title: 'Components/Range Slider',
+  component: RangeSlider,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+} as Meta;
+
+const Template = args => {
+  const [value, setValue] = useState(0);
+
+  return <RangeSlider {...args} value={value} onChange={e => setValue(e)} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Default range slider'
+};
+
+export const WithMarks = Template.bind({});
+WithMarks.args = {
+  label: 'Range slider with marks',
+  min: 0,
+  max: 60000,
+  marks: {
+    0: (
+      <div className={styles['range-marker-container']}>
+        <div className={`${styles['range-marker']} ${styles['range-marker-highlight']}`} />
+        <p>0</p>
+      </div>
+    ),
+    15000: (
+      <div className={styles['range-marker-container']}>
+        <div className={`${styles['range-marker']} ${styles['range-marker-highlight']}`} />
+        <p>$ 15,000</p>
+      </div>
+    ),
+    30000: (
+      <div className={styles['range-marker-container']}>
+        <div className={`${styles['range-marker']} ${styles['range-marker-highlight']}`} />
+        <p>$ 30,000</p>
+      </div>
+    ),
+    45000: (
+      <div className={styles['range-marker-container']}>
+        <div className={`${styles['range-marker']} ${styles['range-marker-highlight']}`} />
+        <p>$ 45,000</p>
+      </div>
+    ),
+    60000: (
+      <div className={styles['range-marker-container']}>
+        <div className={`${styles['range-marker']} ${styles['range-marker-highlight']}`} />
+        <p>$ 60,000</p>
+      </div>
+    )
+  }
+};

--- a/src/components/RangeSlider/index.tsx
+++ b/src/components/RangeSlider/index.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable react/self-closing-comp */
+import React from 'react';
+import styles from './RangeSlider.css';
+import Slider from 'rc-slider';
+import classNames from 'classnames';
+import 'rc-slider/assets/index.css';
+
+interface Props<T> {
+  disabled?: boolean;
+  dotStyle?: React.CSSProperties;
+  handle?: (props) => React.ReactElement;
+  handleStyle?: React.CSSProperties;
+  label?: string;
+  marks?: T[];
+  max?: number;
+  min?: number;
+  onChange?: (value: number) => void;
+  railStyle?: React.CSSProperties;
+  step?: number;
+  trackStyle?: React.CSSProperties;
+  value?: number;
+  variablesClassName?: string;
+}
+
+const RangeSlider = <T extends {}>(props: Props<T>) => {
+  const {
+    disabled,
+    dotStyle,
+    handle,
+    handleStyle,
+    label,
+    marks,
+    max,
+    min,
+    onChange,
+    railStyle,
+    step,
+    trackStyle,
+    value,
+    variablesClassName
+  } = props;
+
+  return (
+    <div className={classNames(styles['range-slider-container'], variablesClassName)}>
+      <label>{label}</label>
+      <Slider
+        disabled={disabled}
+        onChange={onChange}
+        min={min}
+        max={max}
+        marks={marks}
+        value={value}
+        step={step}
+        trackStyle={trackStyle}
+        railStyle={railStyle}
+        dotStyle={dotStyle}
+        handle={handle}
+        handleStyle={handleStyle}
+      />
+    </div>
+  );
+};
+
+RangeSlider.defaultProps = {
+  trackStyle: {
+    backgroundColor: 'var(--range-slider-track-background-color, var(--success-color))',
+    height: 'var(--range-slider-track-height, 0.75rem)',
+    borderRadius: 'var(--range-slider-track-border-radius, 0.25rem)'
+  },
+  railStyle: {
+    backgroundColor: 'var(--range-slider-rail-background-color, var(--primary-color-500))',
+    height: 'var(--range-slider-rail-height, 0.75rem)',
+    borderRadius: 'var(--range-slider-rail-border-radius, 0.25rem)'
+  },
+  dotStyle: { display: 'none' },
+  handleStyle: {
+    backgroundColor: 'var(--range-slider-handle-background-color, var(--success-color))',
+    border: 'var(--range-slider-handle-border, 0.0625rem solid var(--structure-color-white))',
+    boxShadow: 'var(--range-slider-handle-box-shadow, none)',
+    borderRadius: 'var(--range-slider-handle-border-radius, 0.0625rem)',
+    width: 'var(--range-slider-handle-width, 0.5rem)',
+    height: 'var(--range-slider-handle-height, 1.625rem)',
+    marginTop: 'var(--range-slider-handle-margin-top, -0.4375rem)'
+  }
+};
+
+export default RangeSlider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ export { default as Dropdown } from '@/components/Dropdown';
 export { default as List } from '@/components/List';
 export { default as MapsProvider } from '@/components/MapsProvider';
 export { default as NumericInput } from '@/components/NumericInput';
+export { default as RangeSlider } from '@/components/RangeSlider';
 export { default as TextArea } from '@/components/TextArea';
 export { default as Toast } from '@/components/Toast';
 export { default as UploadAvatar } from '@/components/UploadAvatar';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,18 +17,36 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        exclude: path.resolve(__dirname, 'node_modules/rc-slider'),
         use: [
           MiniCssExtractPlugin.loader,
           {
             loader: 'css-loader',
             options: {
-            modules: {
-              localIdentName: "ads-[name]__[local]--[hash:base64:5]",
-              localIdentContext: path.resolve(__dirname, "src"),
-              localIdentHashPrefix: "ads-",
+              modules: {
+                localIdentName: 'ads-[name]__[local]--[hash:base64:5]',
+                localIdentContext: path.resolve(__dirname, 'src'),
+                localIdentHashPrefix: 'ads-'
+              }
             }
+          }
+        ]
+      },
+      {
+        test: /\.css$/,
+        include: path.resolve(__dirname, 'node_modules/rc-slider'),
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              modules: {
+                localIdentName: '[local]',
+                localIdentContext: path.resolve(__dirname, 'src'),
+                localIdentHashPrefix: 'ads-'
+              }
             }
-          },
+          }
         ]
       },
       {


### PR DESCRIPTION
If applied, this pull request will make the Range Slider component available in the ADS library.

### Other minor changes:
- Added a new rule to Webpack to ignore the rc-slider module

### Card Link:
Resolves #196 

### Design Expected Screenshot
![image](https://user-images.githubusercontent.com/7016840/122584555-dfff7300-d030-11eb-9e96-f5e3cf5f5d64.png)

### Implementation Screenshot or GIF
![gif](http://g.recordit.co/rCyedBB6dw.gif)
