### PR TITLE
Add nodeAfterItems to grouped Dropdowns

### DIFF
--- a/src/components/Dropdown/renderOptions.tsx
+++ b/src/components/Dropdown/renderOptions.tsx
@@ -100,6 +100,7 @@ const RenderOptions = <T extends {}>(props: DropdownProps<T>, ref?: React.Ref<HT
 
     return (
       <div className={styles['dropdown-list-group-container']} ref={ref || listRef}>
+        {nodeBeforeItems}
         {keys.length > 0 &&
           keys.map((item, index) => {
             return (
@@ -120,10 +121,11 @@ const RenderOptions = <T extends {}>(props: DropdownProps<T>, ref?: React.Ref<HT
                 selected={selected}
                 multiselect={multiselect}
                 id={`${id}-list`}
-                nodeBeforeItems={getNodeBeforeItems(buildAppendList(item, index))}
+                nodeBeforeItems={buildAppendList(item, index)}
               />
             );
           })}
+        {nodeAfterItems}
       </div>
     );
   };


### PR DESCRIPTION
If applied, this pull request will ... [Please complete the description]

### Other minor changes:
 - I've also fixed the nodeBeforeItems property as it was rendering one per each list group.


### Card Link:
Fixes #226

### Design Expected Screenshot
![image](https://user-images.githubusercontent.com/7016840/122948730-83ae9300-d351-11eb-9e60-ac60efdb5a5c.png)

### Implementation Screenshot or GIF
![image](https://user-images.githubusercontent.com/7016840/122948742-85785680-d351-11eb-9baa-d6c7bf66c04a.png)
