### PR TITLE
Add CSS variables and missing properties to Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -17,6 +17,8 @@
   box-sizing: border-box;
   padding: var(--dropdown-group-div-padding, 20px);
   width: var(--dropdown-width, 100%);
+  position: var(--dropdown-group-div-position);
+  margin: var(--dropdown-group-div-margin);
 }
 
 .dropdown-input {

--- a/src/components/Dropdown/Dropdown.stories.mdx
+++ b/src/components/Dropdown/Dropdown.stories.mdx
@@ -115,7 +115,9 @@ They are listed in the table below.
 |    group     |      margin      |                    |
 |    group     |     padding      |                    |
 |  group-div   |      border      |                    |
+|  group-div   |      margin      |                    |
 |  group-div   |     padding      |                    |
+|  group-div   |     position     |                    |
 |   message    |      color       | positive, negative |
 |   message    |   font-family    |                    |
 |   message    |    font-size     |                    |

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import InputDropdown from './InputDropdown';
 import ButtonDropdown from './ButtonDropdown';
 import { isEmpty } from 'lodash';
+import { Position } from '@/components/Button'; // eslint-disable-line no-unused-vars
 
 export type Category = 'simple' | 'icon';
 export type ListItemCategory = 'simple' | 'checkbox';
@@ -24,6 +25,7 @@ export interface Props<T> {
   getItemLabel: (item: T) => string;
   getItemValue: (item: T) => string | number | string[];
   groupBy?: ((item: T) => any) | string;
+  iconPosition?: Position;
   id: string;
   label?: string;
   listItemCategory: ListItemCategory;


### PR DESCRIPTION
If applied, this pull request will add margin and position CSS variables to the dropdown-list-group-container class and the iconPosition prop to the Dropdown component.

### Card Link:
#229 

### Design Expected Screenshot
No visible impact

