### PR TITLE
Fix Form state propagation to children issue

### DIFF
--- a/src/components/Form/getRerenderKeys.tsx
+++ b/src/components/Form/getRerenderKeys.tsx
@@ -1,4 +1,4 @@
-export default (values, fieldsValidationState, names) => {
+export default (values, fieldsValidationState, names, children) => {
   const v = {};
   names.forEach(c => {
     v[c] = values[c] || '';
@@ -9,5 +9,7 @@ export default (values, fieldsValidationState, names) => {
     n[c] = fieldsValidationState[c];
   });
 
-  return [...names, ...Object.values(v), ...Object.values(n)];
+  const chidrenProps = children.map(c => c.props);
+
+  return [...names, ...Object.values(v), ...Object.values(n), ...chidrenProps];
 };

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -37,7 +37,7 @@ const Form = (props: Props) => {
 
   useEffect(() => {
     setCustomChildren(getCustomChildren(customChildremProps));
-  }, getRerenderKeys(values, fieldsValidationState, names));
+  }, getRerenderKeys(values, fieldsValidationState, names, children));
 
   return customChildren;
 };


### PR DESCRIPTION
If applied, this pull request will fix the state propagation issue in Form children components.

### Card Link:
#208 

### Implementation Screenshot or GIF
![implementation](http://g.recordit.co/fThBNDraqT.gif)

### Notes:
The useEffect hook in the Form component was only getting called to re-render the Form children when a validation state or a value changed.
With this change, the useEffect hook is now also taking into account any other props from the children components to re-render them.
This way we not only solve the issue with the options not getting updated, but any other property that is attached to the parent component state.