### PR TITLE
Update Tooltip wrapper's custom styling

### DIFF
--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -19,7 +19,6 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
If applied, this pull request will Update Tooltip wrapper's custom styling

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
N/A

### Notes
Remove default height from tooltip, which causes a distortion on the wrapper.