### PR TITLE
Add custom HTML element support to tab menu title

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -21,7 +21,7 @@ interface Props {
   fixed?: boolean;
   iconPosition?: Position;
   id?: string;
-  text?: string;
+  text?: string | React.ReactNode;
   onClick?: () => void;
   size?: Size;
   type?: 'button' | 'submit' | 'reset' | undefined;

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -74,3 +74,62 @@ Default.args = {
     </>
   ]
 };
+
+const renderTitle = text => {
+  return (
+    <div>
+      Tab
+      <span>{text}</span>
+    </div>
+  );
+};
+
+export const TabWithHTMLElementTitle = Template.bind({});
+TabWithHTMLElementTitle.args = {
+  menuItems: [
+    { title: renderTitle('1'), active: true },
+    { title: renderTitle('2') },
+    { title: 'Tab 3' }
+  ],
+  components: [
+    <>
+      <div className={classNames(styles['component-container'])}>
+        <h2 className={classNames(styles['component-title'])}>Tab 1 Sample Content</h2>
+        <List
+          options={LIST1}
+          id='list'
+          getItemValue={item => item.value}
+          getItemLabel={item => item.label}
+          getItemKey={item => item.value}
+          onChange={() => {}}
+        />
+      </div>
+    </>,
+    <>
+      <div className={classNames(styles['component-container'])}>
+        <h2 className={classNames(styles['component-title'])}>Tab 2 Sample Content</h2>
+        <List
+          options={LIST1}
+          id='list'
+          getItemValue={item => item.value}
+          getItemLabel={item => item.label}
+          getItemKey={item => item.value}
+          onChange={() => {}}
+        />
+      </div>
+    </>,
+    <>
+      <div className={classNames(styles['component-container'])}>
+        <h2 className={classNames(styles['component-title'])}>Tab 3 Sample Content</h2>
+        <List
+          options={LIST2}
+          id='list'
+          getItemValue={item => item.value}
+          getItemLabel={item => item.label}
+          getItemKey={item => item.value}
+          onChange={() => {}}
+        />
+      </div>
+    </>
+  ]
+};

--- a/src/components/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/src/components/Tab/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Tab renders correctly 1`] = `
       className="tab-menu-container"
     >
       <ForwardRef
-        key="Test Active"
+        key="Test Active-0"
         onClick={[Function]}
         text="Test Active"
         variablesClassName="tab-menu-button tab-menu-button-active"
@@ -71,7 +71,7 @@ exports[`Tab renders correctly 1`] = `
         </ForwardRef>
       </ForwardRef>
       <ForwardRef
-        key="Test Inactive"
+        key="Test Inactive-1"
         onClick={[Function]}
         text="Test Inactive"
         variablesClassName="tab-menu-button"

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -3,7 +3,10 @@ import classNames from 'classnames';
 import styles from './Tab.css';
 import Button from '@/components/Button';
 
-type MenuItem = { title: string; active?: boolean };
+type MenuItem = {
+  title: string | React.ReactNode;
+  active?: boolean;
+};
 
 interface Props {
   components: React.ReactNode[];
@@ -24,10 +27,10 @@ const Tab = (props: Props) => {
   return (
     <div className={classNames(styles['tab-container'], variablesClassName)}>
       <div className={classNames(styles['tab-menu-container'], variablesClassName)}>
-        {menuItems.map(item => {
+        {menuItems.map((item, index) => {
           return (
             <Button
-              key={item.title}
+              key={`${item.title}-${index}`}
               variablesClassName={classNames(
                 styles['tab-menu-button'],
                 activeButton === item && styles['tab-menu-button-active'],


### PR DESCRIPTION
If applied, this pull request will Add custom HTML element support to tab menu title

### Other changes
- add new tab example covering custom HTML element on the title
- update type for the MenuItem's title

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Screenshot from 2021-11-20 20-59-18](https://user-images.githubusercontent.com/45719240/142744342-f3b221ca-ac72-45a6-b958-d86d9c3b7d6c.png)