### PR TITLE
Add CSS support for Tooltip's text transform

### DIFF
--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -27,6 +27,7 @@
   font-family: var(--tooltip-font-family, 'Inter');
   font-size: var(--tooltip-font-size, var(--paragraph-l));
   font-weight: var(--tooltip-font-weight, var(--paragraph-font-weight-bold));
+  text-transform: var(--tooltip-text-transform, none);
 }
 
 .tooltip::before {

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -39,3 +39,4 @@ export default MyComponent;
 |     -    |    font-size     |          -           |
 |     -    |    font-weight   |          -           |
 |     -    |      spacing     |          -           |
+|     -    |  text-transform  |          -           |


### PR DESCRIPTION
If applied, this pull request will Add CSS support for Tooltip's text transform

### Card Link:
N/A

### Notes:
Will remove case of direct CSS implementation. Example: https://github.com/codelittinc/usdm-digital-exp-web/blob/963fb2dceae0dc1a0b5f51d7c3d9905694394df2/components/Navbar/Navbar.module.scss#L24
