### PR TITLE
Update SelectItemsList focus effect application

### DIFF
--- a/src/components/SelectItemsList/SelectItemsList.css
+++ b/src/components/SelectItemsList/SelectItemsList.css
@@ -60,7 +60,7 @@
   );
 }
 
-.input-container-label:focus {
+.input-container:focus + .input-container-label {
   outline: var(--select-items-list-outline-focus, 1px solid var(--primary-color-200));
   outline-offset: var(--select-items-list-outline-offset-focus, 8px);
 }


### PR DESCRIPTION
If applied, this pull request will Update SelectItemsList focus effect application

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF

https://user-images.githubusercontent.com/45719240/149339817-733f19e7-e44e-40de-9be4-cbc465e32e7d.mp4



### Notes:
In order to cycle through a group of radio buttons via the keyboard, the group must be tabbed into from the form. Upon reaching the group, the arrow keys of the keyboard are used to move between buttons. By default behavior and in accordance to [ARIA standards](https://www.w3.org/TR/wai-aria-practices/), a focused radio button will be considered as the selected option automatically.

The styling solution of this PR reflects the relation between the input and custom label. The input tag is the appropriate element to receive a focus cycle. If a input is focused, then its respective label will receive the custom styling. The label in and of itself doesn't receive a focused state natively.