### PR TITLE
Add Border customization to Radio button's circle

### DIFF
--- a/src/components/List/List.stories.css
+++ b/src/components/List/List.stories.css
@@ -1,0 +1,14 @@
+.custom-list {
+  --list-height: 40px;
+  --list-item-background-color: var(--structure-color-white);
+  --list-item-height: 40px;
+  --list-item-radio-background-color: var(--structure-color-white);
+  --list-item-radio-background-color-checked: var(--structure-color-white);
+  --list-item-radio-background-color-circle: var(--structure-color-white);
+  --list-item-radio-border-checked: 1px solid var(--primary-color-300);
+  --list-item-radio-border-circle: 4px solid var(--primary-color-300);
+  --list-item-radio-height-circle: 8px;
+  --list-item-radio-width-circle: 8px;
+  --list-item-radio-left-circle: 4px;
+  --list-item-radio-top-circle: 4px;
+}

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -208,7 +208,7 @@ For the [List](https://design-system.codelitt.dev/?path=/story/components-list--
 |  Property  |    Attribute     |         State          |
 | :--------: | :--------------: | :--------------------: |
 | item-radio | background-color | checked, hover, circle |
-| item-radio |      border      |     checked, hover     |
+| item-radio |      border      | checked, hover, circle |
 | item-radio |      height      |         circle         |
 | item-radio |       left       |        circle\*        |
 | item-radio |       top        |        circle\*        |

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import List from '@/components/List';
 import mdx from './List.stories.mdx';
+import styles from './List.stories.css';
 
 export default {
   title: 'Components/List',
@@ -132,4 +133,31 @@ CheckMarkList.args = {
   getItemValue: item => item.value,
   getItemLabel: item => item.label,
   getItemKey: item => item.value
+};
+
+export const CustomStyledRadioList = () => {
+  const [selectedItem, setSelectedItem] = useState({ label: '', value: '' });
+
+  return (
+    <List
+      getItemValue={item => item.value}
+      getItemLabel={item => item.label}
+      getItemKey={item => item.value}
+      listItemCategory='radio'
+      onChange={setSelectedItem}
+      options={[
+        {
+          label: 'Item 1',
+          value: '1'
+        },
+        {
+          label: 'Item 2',
+          value: '2'
+        }
+      ]}
+      selected={selectedItem}
+      size='large'
+      variablesClassName={styles['custom-list']}
+    />
+  );
 };

--- a/src/components/ListItem/RadioButtonListItem/RadioButtonListItem.css
+++ b/src/components/ListItem/RadioButtonListItem/RadioButtonListItem.css
@@ -59,6 +59,7 @@
 /* Style the indicator (dot/circle) large size */
 .radio-container .list-item-radio--large ~ .radio-check:after {
   background: var(--list-item-radio-background-color-circle, var(--structure-color-white));
+  border: var(--list-item-radio-border-circle, 0);
   border-radius: 50%;
   height: var(--list-item-radio-height-circle, 12px);
   left: var(--list-item-radio-left-circle, 6px);
@@ -69,6 +70,7 @@
 /* Style the indicator (dot/circle) medium size */
 .radio-container .list-item-radio--medium ~ .radio-check:after {
   background: var(--list-item-radio-background-color-circle, var(--structure-color-white));
+  border: var(--list-item-radio-border-circle, 0);
   border-radius: 50%;
   height: var(--list-item-radio-height-circle, 10px);
   left: var(--list-item-radio-left-circle, 5px);


### PR DESCRIPTION
If applied, this pull request will Add Border customization to Radio button's circle

### Other minor changes:
 - update documentation
 - add custom style radio list example

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Screenshot from 2022-03-24 17-07-29](https://user-images.githubusercontent.com/45719240/160001600-c8562ec0-ac53-4c43-848a-24f3e6fc1661.png)

