### PR TITLE
Add outline offset focus customization to list item component

### DIFF
--- a/src/components/List/List.stories.css
+++ b/src/components/List/List.stories.css
@@ -17,7 +17,10 @@
   --list-item-border-top-focus: 1px solid var(--primary-color-300);
   --list-item-border-radius: 4px;
   --list-item-height: 40px;
+  --list-item-margin: 0 8px 0 0;
   --list-item-min-height: 40px;
+  --list-item-outline-focus: 1px solid var(--primary-color-300);
+  --list-item-outline-offset-focus: 8px;
   --list-item-padding: 12px 16px;
   --list-item-radio-height: 14px;
   --list-item-radio-top: -2px;

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -160,6 +160,7 @@ For the [List](https://design-system.codelitt.dev/?path=/story/components-list--
 |     item      |    min-height    |                      |
 |     item      |     padding      |                      |
 |     item      |     outline      |       focus\*        |
+|     item      |  outline-offset  |       focus\*        |
 |  item-label   |      color       |    active, hover     |
 |  item-label   |   font-family    |                      |
 |  item-label   |    font-size     |                      |

--- a/src/components/ListItem/DefaultListItem/DefaultListItem.css
+++ b/src/components/ListItem/DefaultListItem/DefaultListItem.css
@@ -71,6 +71,7 @@
   color: var(--list-item-color-focus, var(--list-item-color));
   font-weight: var(--list-item-font-weight-focus, var(--list-item-font-weight));
   outline: var(--list-item-outline-focus, none);
+  outline-offset: var(--list-item-outline-offset-focus, 0);
 }
 
 .list-item-label {


### PR DESCRIPTION
If applied, this pull request will Add outline offset focus customization to list item component

### Other minor changes:
 - updates documentation

### Implementation Screenshot or GIF
Example:
![Screenshot from 2022-03-25 12-56-56](https://user-images.githubusercontent.com/45719240/160156883-0c2da3a0-8eca-48fe-b73b-883a892d7d1f.png)

