### PR TITLE
Update dropdown adding the top css variable

### DIFF
--- a/src/components/Dropdown/ButtonDropdown/index.tsx
+++ b/src/components/Dropdown/ButtonDropdown/index.tsx
@@ -46,13 +46,12 @@ const ButtonDropdown = <T extends {}>(props: Props<T>) => {
     getListTitle,
     onChange,
     onValidate,
+    listPosition,
     multiselect,
     selectorText,
     variablesClassName,
     messageValidateClass,
-    validationMessage,
-    listPosition,
-    groupBy
+    validationMessage
   } = props;
 
   const [listTitle, setListTitle] = useState(
@@ -80,19 +79,6 @@ const ButtonDropdown = <T extends {}>(props: Props<T>) => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [buttonRef, isListOpen]);
-
-  useEffect(() => {
-    if (buttonRef.current && listRef.current && isListOpen && listPosition === 'top') {
-      const bounds = buttonRef.current.getBoundingClientRect();
-      if (groupBy) {
-        listRef.current.style.setProperty('bottom', `${bounds.height}px`);
-        listRef.current.style.setProperty('position', 'absolute');
-      } else {
-        const listElement = listRef.current.getElementsByTagName('ul')[0];
-        listElement.style.setProperty('bottom', `${bounds.height}px`);
-      }
-    }
-  }, [listRef, isListOpen]);
 
   const displayOptionsList = () => {
     setIsListOpen(!isListOpen);
@@ -125,7 +111,7 @@ const ButtonDropdown = <T extends {}>(props: Props<T>) => {
           category='neutral'
           size={size}
           iconPosition={iconPosition}
-          appendIcon={customIcon || getArrowIcon(isListOpen, size)}
+          appendIcon={customIcon || getArrowIcon(isListOpen, listPosition, size)}
           withAppendIcon
           ref={buttonRef}
         />

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -92,6 +92,14 @@
   z-index: 999;
 }
 
+.dropdown-list-postioned-top {
+  --list-bottom: var(--dropdown-list-bottom, 55px);
+}
+
+.dropdown-list-postioned-bottom {
+  --list-top: var(--dropdown-list-top, 55px);
+}
+
 .dropdown-button {
   --button-background-color: var(--structure-color-100);
   --button-background-color-active: var(--structure-color-300);

--- a/src/components/Dropdown/Dropdown.stories.css
+++ b/src/components/Dropdown/Dropdown.stories.css
@@ -1,0 +1,3 @@
+.dropdown {
+  --dropdown-list-top: 70px;
+}

--- a/src/components/Dropdown/Dropdown.stories.mdx
+++ b/src/components/Dropdown/Dropdown.stories.mdx
@@ -51,6 +51,9 @@ OBS: An asterisk (\*) denotes that the property will have additional info below 
 1. bottom
 2. top
 
+  You can use the CSS variables ```--dropdown-list-top``` to control the position of the list in case you selected the 'bottom' option<br />
+or ```--dropdown-list-bottom``` in case you selected the 'top' option
+
 **Positions**
 
 1. left
@@ -99,6 +102,10 @@ export default SimpleDropdown;
 Given the nature of a composite component, in addition to its own, the Dropdown utilizes CSS variables from the Button, Input and List components.
 They are listed in the table below.
 
+The CSS variables ```--dropdown-list-top``` and ```--dropdown-list-bottom``` are used to control the dropdown list positioning.<br />
+Use the CSS variable ```--dropdown-list-top``` to control the list positioning if listPosition was defined as 'bottom' or if no option for it was selected.<br />
+Use the CSS variable ```--dropdown-list-bottom``` to control the list positioning if listPosition was defined as 'top'.<br />
+
 ### Variables of the Dropdown component
 
 |    Property    |    Attribute     |       State        |
@@ -129,6 +136,8 @@ They are listed in the table below.
 |   group-div    |     z-index      |                    |
 | groups-wrapper |      height      |                    |
 | groups-wrapper |    overflow-y    |                    |
+|     list       |      bottom      |                    |
+|     list       |       top        |                    |
 |    message     |      color       | positive, negative |
 |    message     |   font-family    |                    |
 |    message     |    font-size     |                    |

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import Dropdown from '@/components/Dropdown';
 import GearIcon from '@/assets/images/icons/web/gear.svg';
+import styles from './Dropdown.stories.css';
 import mdx from './Dropdown.stories.mdx';
 
 export default {
@@ -176,7 +177,8 @@ EditableDropdown.args = {
   getItemKey: item => item.value,
   getItemValue: item => item.value,
   getListTitle: item => item.label,
-  editable: true
+  editable: true,
+  variablesClassName: styles.dropdown
 };
 
 export const EditableDropdownWithRequired = Template.bind({});
@@ -205,7 +207,8 @@ EditableDropdownWithRequired.args = {
   getItemValue: item => item.value,
   getListTitle: item => item.label,
   required: true,
-  editable: true
+  editable: true,
+  variablesClassName: styles.dropdown
 };
 
 export const IconDropdown = Template.bind({});
@@ -233,7 +236,8 @@ IconDropdown.args = {
   getItemKey: item => item.value,
   getItemValue: item => item.value,
   getListTitle: item => item.label,
-  editable: true
+  editable: true,
+  variablesClassName: styles.dropdown
 };
 
 export const CheckBoxDropdown = Template.bind({});
@@ -296,7 +300,8 @@ FilteredOptionsDropdown.args = {
   getItemKey: item => item.value,
   getItemValue: item => item.value,
   getListTitle: item => item.label,
-  filterOptions: options => options.filter(option => option.label.includes('Foo'))
+  filterOptions: options => options.filter(option => option.label.includes('Foo')),
+  variablesClassName: styles.dropdown
 };
 
 const sortArrayByLabel = (a, b) => {

--- a/src/components/Dropdown/InputDropdown/index.tsx
+++ b/src/components/Dropdown/InputDropdown/index.tsx
@@ -54,6 +54,7 @@ const InputDropdown = <T extends {}>(props: Props<T>) => {
     getItemLabel,
     getListTitle,
     id,
+    listPosition,
     onChange,
     onInputChange,
     onStateChange,
@@ -63,9 +64,7 @@ const InputDropdown = <T extends {}>(props: Props<T>) => {
     selectorText,
     variablesClassName,
     messageValidateClass,
-    validationMessage,
-    listPosition,
-    groupBy
+    validationMessage
   } = props;
 
   const defaultFilter = options =>
@@ -105,20 +104,6 @@ const InputDropdown = <T extends {}>(props: Props<T>) => {
       listRef.current.style.top = height + 'px';
     }
   }, [height, isListOpen]);
-
-  useEffect(() => {
-    if (inputRef.current && listRef.current && isListOpen && listPosition === 'top') {
-      const bounds = inputRef.current.getBoundingClientRect();
-      if (groupBy) {
-        listRef.current.style.setProperty('bottom', `${bounds.height}px`);
-        listRef.current.style.setProperty('position', 'absolute');
-      } else {
-        const listElement = listRef.current.getElementsByTagName('ul')[0];
-
-        listElement.style.setProperty('bottom', `${bounds.height}px`);
-      }
-    }
-  }, [listRef, isListOpen]);
 
   const displayOptionsList = () => {
     setIsListOpen(true);
@@ -177,7 +162,7 @@ const InputDropdown = <T extends {}>(props: Props<T>) => {
           onMouseEnter={() => setIsInputHovered(true)}
           onMouseLeave={() => setIsInputHovered(false)}
           variablesClassName={classnames(styles['dropdown-input'], variablesClassName)}
-          actionIcon={customIcon || getArrowIcon(isListOpen, size)}
+          actionIcon={customIcon || getArrowIcon(isListOpen, listPosition, size)}
           withActionIcon
           onClickActionIcon={() => setIsListOpen(!isListOpen)}
           prepend={handleIconCategory()}

--- a/src/components/Dropdown/getArrowIcon.tsx
+++ b/src/components/Dropdown/getArrowIcon.tsx
@@ -4,11 +4,19 @@ import IconArrowDown from '@/assets/images/icons/web/arrow-down.svg';
 import styles from '@/components/Dropdown/Dropdown.css';
 import { LARGE_SIZE } from '@/components/Dropdown';
 
-export default (isOpen, size) => {
+export default (isOpen, listPosition, size) => {
   const iconTitle = isOpen ? 'Hide Options' : 'Show Options';
-  const IconType = isOpen ? IconArrowUp : IconArrowDown;
   const iconWidthSize = size === LARGE_SIZE ? 15 : 9;
   const iconHeightSize = size === LARGE_SIZE ? 9 : 5;
+
+  const IconType =
+    listPosition === 'top'
+      ? isOpen
+        ? IconArrowDown
+        : IconArrowUp
+      : isOpen
+      ? IconArrowUp
+      : IconArrowDown;
 
   return (
     <IconType

--- a/src/components/Dropdown/renderOptions.tsx
+++ b/src/components/Dropdown/renderOptions.tsx
@@ -20,6 +20,7 @@ const RenderOptions = <T extends {}>(props: DropdownProps<T>, ref?: React.Ref<HT
     nodeBeforeItems,
     variablesClassName,
     listItemCategory,
+    listPosition,
     showSelectAll,
     sort,
     groupBy
@@ -53,8 +54,7 @@ const RenderOptions = <T extends {}>(props: DropdownProps<T>, ref?: React.Ref<HT
       <div className={styles['select-all-container']}>
         <a className={styles['select-all-link']} onClick={() => onChange(getSelectOptions(true))}>
           Select All
-        </a>{' '}
-        -{' '}
+        </a>
         <a className={styles['select-all-link']} onClick={() => onChange(getSelectOptions(false))}>
           Deselect All
         </a>
@@ -74,7 +74,13 @@ const RenderOptions = <T extends {}>(props: DropdownProps<T>, ref?: React.Ref<HT
         getItemKey={item => getItemKey(item)}
         getItemLabel={item => getItemLabel(item)}
         getItemValue={item => getItemValue(item)}
-        variablesClassName={classnames(styles['dropdown-list'], variablesClassName)}
+        variablesClassName={classnames(
+          styles['dropdown-list'],
+          variablesClassName,
+          listPosition === 'top'
+            ? styles['dropdown-list-postioned-top']
+            : styles['dropdown-list-postioned-bottom']
+        )}
         listItemCategory={listItemCategory}
         selected={selected}
         multiselect={multiselect}

--- a/src/components/List/List.css
+++ b/src/components/List/List.css
@@ -25,6 +25,7 @@
   padding: var(--list-padding, 0);
   padding-inline-start: var(--list-padding-inline-start, 0);
   position: var(--list-position, initial);
+  top: var(--list-top);
   width: 100%;
 }
 


### PR DESCRIPTION
If applied, this pull request will fix the dropdown that previously only showed the list on the top position.

### Other minor changes:
 - Add `--dropdown-list-top` and `--dropdown-list-bottom` CSS variables to Dropdown.
 - Add `--list-top` CSS variable to List.
 - Update dropdown arrow icon when the listPosition is 'top'.

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF

https://user-images.githubusercontent.com/17851720/163467878-8ebc46c8-4738-4cf3-88b3-6b3f05d05555.mp4


### Notes:
N/A