### PR TITLE
Update RichTextEditor icon color when button is active

### DIFF
--- a/src/components/Button/DefaultButton/DefaultButton.css
+++ b/src/components/Button/DefaultButton/DefaultButton.css
@@ -44,7 +44,8 @@
 }
 
 .button:hover .button--append-default-icon,
-.button:hover .button--append-icon > svg {
+.button:hover .button--append-icon > svg,
+.button:hover .button--append-icon > svg path {
   fill: var(--button-append-icon-color-hover, var(--button-color-hover));
 }
 
@@ -59,7 +60,8 @@
 }
 
 .button:focus .button--append-default-icon,
-.button:focus .button--append-icon > svg {
+.button:focus .button--append-icon > svg,
+.button:focus .button--append-icon > svg path {
   fill: var(--button-append-icon-color-focus, var(--button-color-focus));
 }
 
@@ -74,7 +76,8 @@
 }
 
 .button:active .button--append-default-icon,
-.button:active .button--append-icon > svg {
+.button:active .button--append-icon > svg,
+.button:active .button--append-icon > svg path {
   fill: var(--button-append-icon-color-active, var(--button-color-active));
 }
 
@@ -88,6 +91,7 @@
 
 .button:disabled .button--append-default-icon,
 .button:disabled .button--append-icon > svg,
+.button:disabled .button--append-icon > svg path,
 .button:disabled svg path {
   fill: var(--button-append-icon-color-disabled, var(--button-color-disabled));
 }
@@ -119,6 +123,7 @@
 }
 
 .button .button--append-default-icon,
-.button .button--append-icon > svg {
+.button .button--append-icon > svg,
+.button .button--append-icon > svg path {
   fill: var(--button-append-icon-color, var(--button-color));
 }

--- a/src/components/RichTextEditor/RichTextEditor.css
+++ b/src/components/RichTextEditor/RichTextEditor.css
@@ -13,6 +13,8 @@
 }
 
 .is-active {
+  --button-append-icon-color: var(--button-icon-color-is-active);
+
   background: var(--button-background-color-is-active);
   color: var(--button-color-is-active);
 }

--- a/src/components/RichTextEditor/RichTextEditor.stories.mdx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.mdx
@@ -90,6 +90,7 @@ export default SimpleRichTextEditor;
 |      button      |         font-size          |                                |
 |      button      |        font-weight         |                                |
 |      button      |           height           |                                |
+|      button      |    icon-color-is-active    |                                |
 |      button      |      justify-content       |                                |
 |      button      |        line-height         |                                |
 |      button      |           margin           |                                |


### PR DESCRIPTION
If applied, this pull request will update the RichTextEditor component adding a new CSS variable to control the color of the button icons, when active.

### Other minor changes:
 - Update --button-append-icon-color variable to also update the color of the Path.


### Implementation Screenshot or GIF

https://user-images.githubusercontent.com/17851720/163871875-043f458c-83f7-4c2c-b421-f0bf6c1997ff.mp4



### Notes:
N/A