### PR TITLE
Add radio button marker display customization to ListItem

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.css
+++ b/src/components/Dropdown/Dropdown.stories.css
@@ -37,6 +37,7 @@
   --list-item-label-color-focus: var(--structure-color-900);
   --list-item-label-font-size: 14px;
   --list-item-label-margin: 0;
+  --list-item-radio-display: none;
   --list-item-selected-background-color: var(--structure-color-200);
   --list-item-selected-background-color-hover: var(--structure-color-200);
   --list-item-selected-border-bottom: none;

--- a/src/components/Dropdown/Dropdown.stories.mdx
+++ b/src/components/Dropdown/Dropdown.stories.mdx
@@ -163,7 +163,11 @@ Use the CSS variable ```--dropdown-list-bottom``` to control the list positionin
 |   select-all   |     padding      |                    |
 |   select-all   |      width       |                    |
 
-### Variables from the Button initially set up in the Dropdown component
+## Observation:
+The following variables are initially set up and drawing defaults from the components that make up the Dropdown.
+For further customization, via CSS variables, please refer to their specific component's documentation.
+
+### Variables from the [Button](https://design-system.codelitt.dev/?path=/docs/components-button--neutral) initially set up in the Dropdown component
 
 | Property |    Attribute     |     State     |
 | :------: | :--------------: | :-----------: |
@@ -173,7 +177,7 @@ Use the CSS variable ```--dropdown-list-bottom``` to control the list positionin
 |          | justify-content  |               |
 |          |     padding      |               |
 
-### Variables from the Input initially set up in the Dropdown component
+### Variables from the [Input](https://design-system.codelitt.dev/?path=/docs/components-input--default) initially set up in the Dropdown component
 
 |  Property   |    Attribute     |             State              |
 | :---------: | :--------------: | :----------------------------: |
@@ -190,42 +194,33 @@ Use the CSS variable ```--dropdown-list-bottom``` to control the list positionin
 | placeholder |    font-size     |                                |
 | placeholder |   font-weight    |                                |
 
-### Variables from the List initially set up in the Dropdown component
+### Variables from the [List](https://design-system.codelitt.dev/?path=/docs/components-list--simple-list) initially set up in the Dropdown component
 
-| Property |    Attribute         |     State     |
-| :------: | :------------------: | :-----------: |
-|          |    background-color  |               |
-|          |      border          |               |
-|          |  border-radius       |               |
-|          |    box-shadow        |               |
-|          |      height          |               |
-|          |      margin          |               |
-|          |    max-height        |               |
-|          |    min-width         |               |
-|          |     outline          |    focus\*    |
-|          |     overflow         |               |
-|          |     padding          |               |
-|          |     position         |               |
-|          | padding-inline-start |               |
-|          |      width           |               |
-|  label   |        color         |               |
-|  label   |      font-size       |               |
-|  label   |     font-weight      |               |
-|  label   |     line-height      |               |
-|  label   |        margin        |               |
-|   item   | background-color     | hover, active |
-|   item   |  border-bottom       |     hover     |
-|   item   |   border-left        |     hover     |
-|   item   |   border-right       |     hover     |
-|   item   |    border-top        |     hover     |
-|   item   |  border-radius       |               |
-|   item   |    box-shadow        |               |
-|   item   |      color           |    active     |
-|   item   |      cursor          |               |
-|   item   |    font-size         |               |
-|   item   |      height          |               |
-|   item   |      margin          |               |
-|   item   |    min-height        |               |
-|   item   |     overflow         |               |
-|   item   |     padding          |               |
-|   item   |     position         |               |
+| Property |    Attribute     |     State     |
+| :------: | :--------------: | :-----------: |
+|          | background-color |               |
+|          |      border      |               |
+|          |  border-radius   |               |
+|          |    box-shadow    |               |
+|          |      height      |               |
+|          |      margin      |               |
+|          |    max-height    |               |
+|          |    min-width     |               |
+|          |     overflow     |               |
+|          |      width       |               |
+|   item   | background-color | hover, active |
+|   item   |  border-bottom   |     hover     |
+|   item   |   border-left    |     hover     |
+|   item   |   border-right   |     hover     |
+|   item   |    border-top    |     hover     |
+|   item   |  border-radius   |               |
+|   item   |    box-shadow    |               |
+|   item   |      color       |    active     |
+|   item   |      cursor      |               |
+|   item   |    font-size     |               |
+|   item   |      height      |               |
+|   item   |      margin      |               |
+|   item   |    min-height    |               |
+|   item   |     overflow     |               |
+|   item   |     padding      |               |
+|   item   |     position     |               |

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -211,6 +211,7 @@ For the [List](https://design-system.codelitt.dev/?path=/story/components-list--
 | :--------: | :--------------: | :--------------------: |
 | item-radio | background-color | checked, hover, circle |
 | item-radio |      border      | checked, hover, circle |
+| item-radio |      display     |                        |
 | item-radio |      height      |         circle         |
 | item-radio |       left       |        circle\*        |
 | item-radio |       top        |         circle         |

--- a/src/components/ListItem/RadioButtonListItem/RadioButtonListItem.css
+++ b/src/components/ListItem/RadioButtonListItem/RadioButtonListItem.css
@@ -2,7 +2,7 @@
 
 .radio-container {
   cursor: pointer;
-  display: block;
+  display: var(--list-item-radio-display, block);
   margin-bottom: 12px;
   position: relative;
   padding-left: 30px;


### PR DESCRIPTION
If applied, this pull request will Add radio button marker display customization to ListItem

### Other changes:
 - updates List documentation
 - updates Dropdown documentation

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Screenshot from 2022-04-19 15-59-08](https://user-images.githubusercontent.com/45719240/164077298-da74cf1e-2366-45d6-9db0-413258d9f083.png)
