### PR TITLE
Fix a bug that checks the select all when there is only one item selected

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import classNames from 'classnames';
-import { isArray, isEmpty, isEqual } from 'lodash';
+import { isArray, isEqual } from 'lodash';
 
 import styles from '@/components/List/List.css';
 
@@ -123,7 +123,7 @@ const List = <T extends {}>(props: Props<T>, ref?: React.Ref<HTMLDivElement>) =>
             <div className={styles['list-select-all-checkbox-wrapper']}>
               <input
                 className={classNames(styles['list-select-all-checkbox'])}
-                checked={isArray(selected) && !isEmpty(selected)}
+                checked={isArray(selected) && selected.length === options.length}
                 onClick={event => handleSelectAllClick(event)}
                 onChange={() => {}}
                 tabIndex={-1}

--- a/src/components/ListItem/CheckBoxListItem/CheckBoxListItem.css
+++ b/src/components/ListItem/CheckBoxListItem/CheckBoxListItem.css
@@ -67,8 +67,8 @@
 /* Style the indicator (dot/circle) large size */
 .checkbox-container .list-item-checkbox--large ~ .checkbox-check:after {
   height: 12px;
-  left: 8px;
-  top: 3px;
+  left: var(--list-item-checkbox-marker-left, 8px);
+  top: var(--list-item-checkbox-marker-top, 3px);
   width: 6px;
 }
 


### PR DESCRIPTION
If applied, this pull request will Fix a bug that checks the select all when there is only one item selected

### Card Link:
N/A

### Design Expected Screenshot
N/A
### Implementation Screenshot or GIF
N/A
