### PR TITLE
Update modal onClickOutside prop to be optional

### DIFF
--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -8,7 +8,7 @@
 | :----------------: | :----------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :-------: |
 |      children      | React.ReactElement[] \| React.ReactElement | This property represents the children nested within the Modal component. It is an implied property that does not need to be defined directly in the component brackets. |    -    |   false   |
 |        open        |                  Boolean                   |                                                              Sets the condition to open the modal or not.                                                               |  true   |   true    |
-|   onClickOutside   |                 () => void                 |                                           Passes in a function that is run when a click event is detected outside the Modal.                                            |    -    |   true    |
+|   onClickOutside   |                 () => void                 |                                           Passes in a function that is run when a click event is detected outside the Modal.                                            |    -    |   false   |
 | variablesClassName |                   string                   |                                                                     Accepts custom CSS class names.                                                                     |    -    |   false   |
 
 ## Getting Started

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,7 +4,7 @@ import styles from '@/components/Modal/Modal.css';
 
 interface Props {
   open: boolean;
-  onClickOutside: () => void;
+  onClickOutside?: () => void;
   variablesClassName?: string;
 }
 
@@ -12,7 +12,7 @@ const Modal: React.FC<Props> = props => {
   const { variablesClassName, open, onClickOutside, children } = props;
 
   function handleClickOutside(event) {
-    if (event.target.id === 'modal-container') {
+    if (event.target.id === 'modal-container' && onClickOutside) {
       onClickOutside();
     }
   }


### PR DESCRIPTION
If applied, this pull request will make onClickOutside an optional prop. This will prevent an error when onClickOutside is not defined, and the user clicks outside the modal.

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
![Peek 2022-05-13 10-44](https://user-images.githubusercontent.com/17851720/168297708-3fc25dff-7a7e-4ddf-9820-1235908a9010.gif)


### Notes:
N/A