### PR TITLE
Add CSS variables to the Input and hide the message div

### DIFF
--- a/src/components/Input/Input.css
+++ b/src/components/Input/Input.css
@@ -15,10 +15,11 @@
 }
 
 .container {
-  align-items: var(--input-align-items);
+  align-items: var(--input-align-items, stretch);
   display: var(--input-display, flex);
   flex-direction: var(--input-flex-direction, column);
-  height: 100%;
+  gap: var(--input-gap, 0);
+  height: var(--input-height, 100%);
   justify-content: var(--input-justify-content);
   margin: var(--input-margin, 0);
   width: var(--input-width);
@@ -34,6 +35,7 @@
   box-shadow: var(--input-box-shadow, none);
   box-sizing: border-box;
   color: var(--input-color, var(--structure-color-900));
+  flex-grow: var(--input-field-flex-grow, 1);
   font-family: var(--input-font-family);
   text-align: var(--input-text-align, left);
   width: var(--input-width);
@@ -176,7 +178,7 @@
   color: var(--input-label-color, var(--structure-color-800));
   display: var(--input-label-display, flex);
   margin: var(--input-label-margin, 0);
-  width: 100%;
+  width: var(--input-label-width, 100%);
 }
 
 .input--label-hidden {

--- a/src/components/Input/Input.stories.mdx
+++ b/src/components/Input/Input.stories.mdx
@@ -29,7 +29,7 @@ OBS: An asterisk (\*) denotes that the property will have additional info below 
 |    onStateChange     | (state: boolean) => void  |                                                                                             It returns a boolean with the validation result when there is a **validationRegex** property                                                                                              |                                                                    -                                                                     |   false   |
 |     placeholder      |          string           |                                                                                                                          The input field's placeholder text.                                                                                                                          |                                                                    -                                                                     |   false   |
 |       prepend        |      React.ReactNode      |                                                                        It is possible to add a [prepend](https://design-system.codelitt.dev/?path=/story/components-input--with-prepend) in your input field.                                                                         |                                                                    -                                                                     |   false   |
-|       readOnly       |          boolean          |                                                                                                                  Specifies that the input field can't be edited.                                                                                                                   |                                                                    -                                                                     |   false   |
+|       readOnly       |          boolean          |                                                                                                                    Specifies that the input field can't be edited.                                                                                                                    |                                                                    -                                                                     |   false   |
 |       required       |          boolean          |                                                                                                                  Specifies that the input field must be filled out.                                                                                                                   |                                                                    -                                                                     |   false   |
 |         size         |           Size            |                                                                                                             Size of the component. The change is reflected on the height.                                                                                                             |                                                                  large                                                                   |   true    |
 |      inputType       |          string           |                                                                                                               Defines what is the type that will be used on the input.                                                                                                                |                                                                    -                                                                     |   false   |
@@ -109,6 +109,7 @@ export default SimpleInput;
 |             |    font-size     |                      disabled                      |
 |             |    font-style    |                      disabled                      |
 |             |   font-weight    |                      disabled                      |
+|             |       gap        |                                                    |
 |             |      height      |                                                    |
 |             | justify-content  |                                                    |
 |             |   line-height    |                                                    |
@@ -118,6 +119,7 @@ export default SimpleInput;
 |             |     padding      |                                                    |
 |             |    text-align    |                                                    |
 |             |      width       |                                                    |
+|    field    |    flex-grow     |                                                    |
 | action-icon | background-color |                                                    |
 | action-icon |      color       |                   hover, active                    |
 | action-icon |      cursor      |                                                    |
@@ -139,6 +141,7 @@ export default SimpleInput;
 |    label    |   line-height    |                                                    |
 |    label    |      height      |                                                    |
 |    label    |      margin      |                                                    |
+|    label    |      width       |                                                    |
 |   message   |      color       |                 positive, negative                 |
 |   message   |     display      |                                                    |
 |   message   |   font-family    |                                                    |

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -174,11 +174,13 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     );
   };
 
-  const getMessage = () => {
-    if (message || invalidMessage) {
-      return validationState === INVALID && invalidMessage ? invalidMessage : message;
-    }
-    return '';
+  const renderMessage = () => {
+    const messageToShow = validationState === INVALID && invalidMessage ? invalidMessage : message;
+    return (
+      <span className={classNames(styles['input--message'], styles[messageValidateClass])}>
+        {messageToShow}
+      </span>
+    );
   };
 
   const displayInput = () => {
@@ -244,32 +246,32 @@ const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     <div className={classNames(variablesClassName, styles.container)}>
       {getLabel()}
       {getDescription()}
-      <div className={classNames(styles['input--container'])}>
-        {mask ? displayMaskedInput(mask) : displayInput()}
-        {!!prepend && (
-          <div
-            className={classNames(
-              styles['input--prepend'],
-              withPrependSeparator ? styles[prependSizeClass] : '',
-              withPrependSeparator ? styles['input--prepend-with-separator'] : ''
-            )}
-          >
-            {prepend}
-          </div>
-        )}
+      <div>
+        <div className={classNames(styles['input--container'])}>
+          {mask ? displayMaskedInput(mask) : displayInput()}
+          {!!prepend && (
+            <div
+              className={classNames(
+                styles['input--prepend'],
+                withPrependSeparator ? styles[prependSizeClass] : '',
+                withPrependSeparator ? styles['input--prepend-with-separator'] : ''
+              )}
+            >
+              {prepend}
+            </div>
+          )}
 
-        {withActionIcon && (
-          <div
-            className={classNames(styles['input--action-icon-container'])}
-            onClick={onClickActionIcon}
-          >
-            {getActionIcon(actionIcon)}
-          </div>
-        )}
+          {withActionIcon && (
+            <div
+              className={classNames(styles['input--action-icon-container'])}
+              onClick={onClickActionIcon}
+            >
+              {getActionIcon(actionIcon)}
+            </div>
+          )}
+        </div>
+        {(message || invalidMessage) && renderMessage()}
       </div>
-      <span className={classNames(styles['input--message'], styles[messageValidateClass])}>
-        {getMessage()}
-      </span>
     </div>
   );
 });

--- a/src/components/NumericInput/__tests__/__snapshots__/NumericInput.test.tsx.snap
+++ b/src/components/NumericInput/__tests__/__snapshots__/NumericInput.test.tsx.snap
@@ -7,19 +7,19 @@ exports[`NumericInput renders correctly 1`] = `
   >
     
     
-    <div
-      class="input--container"
-    >
-      <input
-        class="input input--large"
-        id="numeric-input-test"
-        placeholder="Enter Number"
-        value=""
-      />
+    <div>
+      <div
+        class="input--container"
+      >
+        <input
+          class="input input--large"
+          id="numeric-input-test"
+          placeholder="Enter Number"
+          value=""
+        />
+      </div>
+      
     </div>
-    <span
-      class="input--message"
-    />
   </div>
 </div>
 `;

--- a/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
+++ b/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
@@ -408,21 +408,20 @@ exports[`PaginatedTable renders correctly 1`] = `
                       <div
                         className="number-of-pages-input container"
                       >
-                        <div
-                          className="input--container"
-                        >
-                          <input
-                            className="input input--medium"
-                            id="paginated-table-input-paginated-table"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            value="1"
-                          />
+                        <div>
+                          <div
+                            className="input--container"
+                          >
+                            <input
+                              className="input input--medium"
+                              id="paginated-table-input-paginated-table"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              value="1"
+                            />
+                          </div>
                         </div>
-                        <span
-                          className="input--message"
-                        />
                       </div>
                     </ForwardRef>
                   </ForwardRef>


### PR DESCRIPTION
If applied, this pull request will add CSS variables to the Input and hide the message div.

### Other minor changes:
 - Hide the message container when there's no message to show

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
N/A
