### PR TITLE
Add customization variables to the paginated table footer

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.css
+++ b/src/components/PaginatedTable/PaginatedTable.css
@@ -21,7 +21,11 @@
 .number-of-pages:after {
   color: var(--paginated-table-separator-color, var(--structure-color-800));
   content: '|';
-  margin-left: 20px;
+  margin: var(--paginated-table-separator-margin, 0 0 0 20px);
+}
+
+.number-of-pages-text {
+  font-size: var(--paginated-table-page-number-text, 14px);
 }
 
 .number-of-pages-input {
@@ -49,8 +53,8 @@
 }
 
 .paginated-footer-wrapper {
-  display: flex;
-  flex-direction: row;
+  display: var(--paginated-table-footer-wrapper-display, flex);
+  flex-direction: var(--paginated-table-footer-wrapper-flex-direction, row);
   justify-content: space-between;
   align-items: center;
 }

--- a/src/components/PaginatedTable/PaginatedTable.stories.mdx
+++ b/src/components/PaginatedTable/PaginatedTable.stories.mdx
@@ -57,19 +57,23 @@ PaginatedTable variables are listed in the table below.
 
 |   Property    |    Attribute    | State |
 | :-----------: | :-------------: | :---: |
-|               |   align-items   |       |
-|               |   font-family   |       |
-|               |    font-size    |       |
-|               |   font-weight   |       |
-|               | justify-content |       |
-|               |     padding     |       |
-|               |    overflow     |       |
-|    button     |   font-family   |       |
-|    button     |    font-size    |       |
-|    button     |   font-weight   |       |
-|    button     |     padding     |       |
-|    buttons    |     display     |       |
-| clickable-row |     cursor      |       |
-|  page-input   |    max-width    |       |
-|  page-number  |   text-align    |       |
-|   separator   |     color       |       |
+|                    |   align-items   |       |
+|                    |   font-family   |       |
+|                    |    font-size    |       |
+|                    |   font-weight   |       |
+|                    | justify-content |       |
+|                    |     padding     |       |
+|                    |    overflow     |       |
+|      button        |   font-family   |       |
+|      button        |    font-size    |       |
+|      button        |   font-weight   |       |
+|      button        |     padding     |       |
+|      buttons       |     display     |       |
+|   clickable-row    |     cursor      |       |
+|   footer-wrapper   |     display     |       |
+|   footer-wrapper   |  flex-direction |       |
+|    page-input      |    max-width    |       |
+|    page-number     |   text-align    |       |
+|  page-number-text  |    font-size    |       |
+|     separator      |     color       |       |
+|     separator      |     margin      |       |

--- a/src/components/PaginatedTable/PaginatedTable.stories.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.stories.tsx
@@ -91,7 +91,7 @@ CustomizedTable.args = {
   totalNumberOfItems: 15,
   listOfItems: listOfItems,
   limit: 5,
-  variablesClassName: classNames(styles['custom-button'])
+  variablesClassName: classNames(styles['custom-table'])
 };
 
 export const onRowClick = Template.bind({});

--- a/src/components/PaginatedTable/PaginatedTableTest.css
+++ b/src/components/PaginatedTable/PaginatedTableTest.css
@@ -1,6 +1,11 @@
 @import '../../styles/theme/index.css';
 
-.custom-button {
+.custom-table {
   --button-background-color: red;
   --button-color: black;
+  --button-width: 69px;
+  --button-height: 32px;
+  --paginated-table-footer-wrapper-flex-direction: column;
+  --paginated-table-page-number-text-align: normal;
+  --paginated-table-page-number-text: 12px;
 }

--- a/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
+++ b/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
@@ -425,7 +425,9 @@ exports[`PaginatedTable renders correctly 1`] = `
                       </div>
                     </ForwardRef>
                   </ForwardRef>
-                  <span>
+                  <span
+                    className="number-of-pages-text"
+                  >
                     of 
                     3
                      pages

--- a/src/components/PaginatedTable/index.tsx
+++ b/src/components/PaginatedTable/index.tsx
@@ -94,7 +94,7 @@ const PaginatedTable = (props: Props) => {
                       variablesClassName={styles['number-of-pages-input']}
                       positive
                     />
-                    <span>of {numberOfPages} pages</span>
+                    <span className={styles['number-of-pages-text']}>of {numberOfPages} pages</span>
                   </div>
                   <div className={styles['paginated-table-action-btns']}>
                     <Pagination


### PR DESCRIPTION
If applied, this pull request will Add customization variables to the paginated table footer

### Other minor changes:
 - updates PaginatedTable documentation
 - updates current customized table example in storybook

### Implementation Screenshot or GIF
![Screenshot from 2022-05-18 14-13-19](https://user-images.githubusercontent.com/45719240/169102932-2505f7f8-a2b4-4c91-ac5a-6d90cedd129a.png)

### Notes
Changes needed to implement a mobile design for the component in the USDM project.