### PR TITLE
Add a box-shadow CSS variable to the modal's content container

### DIFF
--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -25,6 +25,7 @@
   background-color: var(--modal-content-container-background-color, var(--structure-color-white));
   border: var(--modal-border, solid 1px black);
   border-radius: var(--modal-content-container-border-radius, 5px);
+  box-shadow: var(--modal-content-container-box-shadow);
   height: var(--modal-content-container-height, auto);
   width: var(--modal-content-container-width, auto);
 }

--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -48,10 +48,11 @@ export default SimpleModal;
 | content-container | background-color |       |
 | content-container |      border      |       |
 | content-container |  border-radius   |       |
+| content-container |    box-shadow    |       |
 | content-container |      height      |       |
 | content-container |      width       |       |
 |      wrapper      |      height      |       |
 |      wrapper      |     position     |       |
 |      wrapper      |       top        |       |
-|      wrapper      |       width      |       |
+|      wrapper      |      width       |       |
 |      wrapper      |     z-index      |       |


### PR DESCRIPTION
If applied, this pull request will add a box-shadow CSS variable to the modal's content container.

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
N/A
