### PR TITLE
Add white space customization to tooltip component

### DIFF
--- a/src/components/Tooltip/Tooltip.css
+++ b/src/components/Tooltip/Tooltip.css
@@ -8,6 +8,7 @@
   justify-content: center;
   padding: var(--tooltip-padding, 5px 5px);
   position: absolute;
+  white-space: var(--tooltip-white-space, normal);
   z-index: 100;
 }
 

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -40,3 +40,4 @@ export default MyComponent;
 |     -    |    font-weight   |          -           |
 |     -    |      spacing     |          -           |
 |     -    |  text-transform  |          -           |
+|     -    |    white-space   |          -           |


### PR DESCRIPTION
If applied, this pull request will Add white space customization to tooltip component

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF
Before:
![Screenshot from 2022-05-30 15-05-05](https://user-images.githubusercontent.com/45719240/171042492-556b046c-2dea-4629-b7fe-b0af6924a798.png)

After:
![Screenshot from 2022-05-30 15-05-15](https://user-images.githubusercontent.com/45719240/171042479-45bca084-4e7f-4e9d-8f63-d8ec9c084c99.png)
