### PR TITLE
Add customization options for overflowing text in dropdown

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -96,3 +96,6 @@ export default SimpleButton;
 |             |      width       |                                |
 | append-icon |      color       | hover, focus, active, disabled |
 | append-icon |      margin      |                                |
+|   content   |     overflow     |                                |
+|   content   |  text-overflow   |                                |
+|   content   |   white-space    |                                |

--- a/src/components/Button/DefaultButton/DefaultButton.css
+++ b/src/components/Button/DefaultButton/DefaultButton.css
@@ -118,6 +118,12 @@
   margin: var(--button-append-icon-margin, 0 16px 0 0);
 }
 
+.button-text {
+  overflow: var(--button-content-overflow, visible);
+  text-overflow: var(--button-content-text-overflow, clip);
+  white-space: var(--button-content-white-space, normal);
+}
+
 .button-text + .append-icon-right  {
   margin: var(--button-append-icon-margin, 0 0 0 16px);
 }

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -112,6 +112,9 @@
   --button-justify-content: space-between;
   --button-padding: 5px 10px;
   --button-width: var(--dropdown-width, 100%);
+  --button-content-overflow: var(--dropdown-selected-title-overflow);
+  --button-content-text-overflow: var(--dropdown-selected-title-text-overflow);
+  --button-content-white-space: var(--dropdown-selected-title-white-space);
 }
 
 .dropdown-button:not(:only-child) {

--- a/src/components/Dropdown/Dropdown.stories.css
+++ b/src/components/Dropdown/Dropdown.stories.css
@@ -10,6 +10,9 @@
   --button-border-hover: none;
   --button-font-size: 16px;
   --button-height: 40px;
+  --dropdown-selected-title-overflow: hidden;
+  --dropdown-selected-title-text-overflow: ellipsis;
+  --dropdown-selected-title-white-space: nowrap;
   --dropdown-width: 140px;
   --list-height: 188px;
   --list-width: 240px;

--- a/src/components/Dropdown/Dropdown.stories.mdx
+++ b/src/components/Dropdown/Dropdown.stories.mdx
@@ -162,6 +162,9 @@ Use the CSS variable ```--dropdown-list-bottom``` to control the list positionin
 |   select-all   |      margin      |                    |
 |   select-all   |     padding      |                    |
 |   select-all   |      width       |                    |
+| selected-title |    overflow      |                    |
+| selected-title |  text-overflow   |                    |
+| selected-title |   white-space    |                    |
 
 ## Observation:
 The following variables are initially set up and drawing defaults from the components that make up the Dropdown.

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -525,6 +525,8 @@ DisplayListOnTop.args = {
 };
 
 export const CustomStyledDropdown = () => {
+  const [selectedOption, setSelectedOption] = useState({});
+
   return (
     <Dropdown
       getItemLabel={item => item.label}
@@ -539,8 +541,14 @@ export const CustomStyledDropdown = () => {
         {
           label: 'Option 2',
           value: '2'
+        },
+        {
+          label: 'Option 21232321323213123',
+          value: '22'
         }
       ]}
+      onChange={setSelectedOption}
+      selected={selectedOption}
       selectorText='Select'
       variablesClassName={styles['custom-styled-dropdown']}
     />


### PR DESCRIPTION
If applied, this pull request will feature/add-customization-overflowing-text-dropdown

### Other minor changes:
 - updates Button and Dropdown documentation

### Card Link:
N/A

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF

https://user-images.githubusercontent.com/45719240/172221909-b8ad98c4-3b4a-4f50-824f-8a2362029d6a.mp4


