### PR TITLE
Fix paginated table displaying negative items

### DIFF
--- a/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
+++ b/src/components/PaginatedTable/__tests__/__snapshots__/PaginatedTable.test.tsx.snap
@@ -354,7 +354,6 @@ exports[`PaginatedTable renders correctly 1`] = `
               <div
                 className="pagination-items"
               >
-                 
                 1 - 5 of 15 items
               </div>
               <div

--- a/src/components/PaginatedTable/index.tsx
+++ b/src/components/PaginatedTable/index.tsx
@@ -47,7 +47,7 @@ const PaginatedTable = (props: Props) => {
 
   const itemsRangeBegin = () => {
     if (itemsOnCurrentPage) {
-      return (currentPage - 1) * limit + 1;
+      return currentPage > 0 ? (currentPage - 1) * limit + 1 : 1;
     }
     return 0;
   };
@@ -75,10 +75,7 @@ const PaginatedTable = (props: Props) => {
             <td colSpan={widthFirstFooterCell}>
               <div className={styles['paginated-footer-wrapper']}>
                 <div className={styles['pagination-items']}>
-                  {' '}
-                  {itemsRangeBegin() !== 0
-                    ? `${itemsRangeBegin()} - ${itemsRangeEnd()} of ${totalNumberOfItems} items`
-                    : `-`}
+                  {`${itemsRangeBegin()} - ${itemsRangeEnd()} of ${totalNumberOfItems} items`}
                 </div>
                 <div className={styles['paginated-table-pages']}>
                   <div className={styles['number-of-pages']}>


### PR DESCRIPTION
If applied, this pull request will fix the bug where the paginated table displayed a negative number of items.
Currently, the code responsible for displaying the number of items only checks if the `currentPage` value is zero and it is inside the return statement. I updated it to check if the value is below one and removed any complexity related to this from the return statement, and added it to the `itemsRangeBegin` function.

### Card Link:
https://codelitt.atlassian.net/jira/software/c/projects/DEX/boards/44?modal=detail&selectedIssue=DEX-320&assignee=60c2d1f72bd21400698d927e

### Implementation Screenshot or GIF
In this video, I simulated the issue and showed how the update fixes it.

https://user-images.githubusercontent.com/17851720/173202185-df672fb1-b18f-4c65-9d4d-589a350c6bd9.mp4




### Notes:
N/A