### PR TITLE
Add option to control RichTextEditor hidden menu height

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.css
+++ b/src/components/RichTextEditor/RichTextEditor.css
@@ -33,12 +33,11 @@
 }
 
 .menu-bar-container-hidden {
-  height: 0;
+  height: var(--menu-bar-height-hidden, 0);
   visibility: hidden;
 }
 
 .menu-bar-container-visible {
-  height: auto;
   visibility: visible;
 }
 

--- a/src/components/RichTextEditor/RichTextEditor.stories.mdx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.mdx
@@ -78,20 +78,20 @@ export default SimpleRichTextEditor;
 Given the nature of a composite component, in addition to its own, the RichTextEditor utilizes CSS variables from the Button component.
 They are listed in the table below.
 
-|     Property     |      Attribute       | State |
-| :--------------: | :------------------: | :---: |
-| menu-bar-button  |      icon-color      |       |
-| menu-bar-button  | icon-color-is-active |       |
-| editor container |        border        | focus |
-| editor container |        height        |       |
-| editor container |        width         |       |
-|     menu bar     |     align-items      |       |
-|     menu bar     |   background-color   |       |
-|     menu bar     |    border-radius     |       |
-|     menu bar     |        height        |       |
-|     menu bar     |   justify-content    |       |
-|     menu bar     |        width         |       |
-|   placeholder    |        color         |       |
+|     Property     |      Attribute       | State  |
+| :--------------: | :------------------: | :----: |
+| menu-bar-button  |      icon-color      |        |
+| menu-bar-button  | icon-color-is-active |        |
+| editor container |        border        | focus  |
+| editor container |        height        |        |
+| editor container |        width         |        |
+|     menu bar     |     align-items      |        |
+|     menu bar     |   background-color   |        |
+|     menu bar     |    border-radius     |        |
+|     menu bar     |        height        | hidden |
+|     menu bar     |   justify-content    |        |
+|     menu bar     |        width         |        |
+|   placeholder    |        color         |        |
 
 ## Observation:
 


### PR DESCRIPTION
If applied, this pull request will add a new CSS variable to the RichTextEditor, enabling the user to control the height of the menu when it is hidden.

### Card Link:
https://codelitt.atlassian.net/jira/software/c/projects/DEX/boards/44?modal=detail&selectedIssue=DEX-452&assignee=60c2d1f72bd21400698d927e

### Design Expected Screenshot
N/A

### Implementation Screenshot or GIF

https://user-images.githubusercontent.com/17851720/176473976-e1bd950e-b86a-49ea-a105-d629a330a518.mp4



### Notes:
N/A
