### PR TITLE
Add customization to donut chart component

### DIFF
--- a/src/components/DonutChart/DonutChart.css
+++ b/src/components/DonutChart/DonutChart.css
@@ -1,7 +1,32 @@
 @import '../../styles/theme/index.css';
 
+.wrapper {
+  position: relative;
+}
+
+.tooltip-wrapper {
+  background-color: var(--tooltip-background-color, var(--structure-color-white));
+  border: var(--tooltip-border, 1px solid #EAECF2);
+  border-radius: 8px;
+  height: 80px;
+  position: absolute;
+  width: 80px;
+  z-index: 10000;
+}
+
+.full-circle-tooltip-wrapper {
+  bottom: 170px;
+  left: 150px;
+}
+
+.tooltip {
+  height: inherit;
+  width: inherit;
+}
+
 .donutchart-full-circle {
   fill: var(--donutchart-full-circle-fill, transparent);
+  position: relative;
   stroke: var(--donutchart-full-circle-stroke, var(--structure-color-100));
 }
 
@@ -12,10 +37,17 @@
   transition: var(--donutchart-indicator-transition, stroke-dasharray 0.3s ease);
 }
 
+.donutchart-full-circle:hover,
+.donutchart-indicator:hover {
+  cursor: pointer;
+  stroke-width: 30 !important;
+}
+
 .donutchart {
   margin: var(--donutchart-margin, 0 auto);
   border-radius: var(--donutchart-border-radius, 50%);
   display: var(--donutchart-display, block);
+  overflow: visible;
 }
 
 .donutchart-text {
@@ -32,15 +64,17 @@
   width: var(--donutchart-text-width, 100%);
 }
 
-.donutchart-text-val {
-  font-size: var(--donutchart-text-val-font-size, 22px);
+.donutchart-completion-value {
+  font-size: var(--donutchart-completion-value-font-size, 22px);
 }
 
-.donutchart-text-label {
-  display: flex;
-  justify-content: center;
+.donutchart-message {
   align-items: center;
-  gap: var(--donutchart-text-label-gap, 5px);
-  font-size: var(--donutchart-text-label-font-size, 12px);
-  margin-top: var(--donutchart-text-label-margin-top, 5px);
+  color: var(--donutchart-message-color, var(--structure-color-black));
+  display: flex;
+  font-size: var(--donutchart-message-font-size, 12px);
+  font-weight: var(--donutchart-message-font-weight, 400);
+  gap: var(--donutchart-message-gap, 5px);
+  justify-content: center;
+  margin-top: var(--donutchart-message-margin-top, 5px);
 }

--- a/src/components/DonutChart/DonutChart.stories.mdx
+++ b/src/components/DonutChart/DonutChart.stories.mdx
@@ -4,23 +4,31 @@
 
 ## DonutChart Props
 
-|        Prop        |      Type       |                                                      Description                                                       | Default | Mandatory |
-| :----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------: | :-----: | :-------: |
-|        size        |     number      | Specifies the overal size of the Donut Chart. We consider this number to calculate the chart radius and circunference. |    -    |   true    |
-|    strokewidth     |     number      |                        Specifies the width of the border you want to have on your donut chart.                         |    -    |   true    |
-|     completion     |     number      |                        Receives the percentage of the filled portion we will show on the chart                         |    -    |   true    |
-|      message       |     string      |                             Receives the label that should be displayed below the number.                              |    -    |   false   |
-|   iconForMessage   | React.ReactNode |                Receives the icon that would be prepended in the label. You can customize your own icon.                |    -    |   false   |
-| variablesClassName |     string      |                               Receives a custom class name for style/css customization.                                |    -    |   false   |
+|          Prop           |            Type           |                                                                 Description                                                                 | Default | Mandatory |
+| :---------------------: | :-----------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :-------: |
+|        completion       |           number          | Receives the percentage of the filled portion we will show on the chart, where 100 represents the total amount and full width of the chart. |    -    |   true    |
+|      iconForMessage     |       React.ReactNode     |                            Receives the icon that would be prepended in the label. You can customize your own icon.                         |    -    |   false   |
+|         message         | string \| React.ReactNode |                                         Receives the label that should be displayed below the completion value.                             |    -    |   false   |
+|  renderCompletionValue  |           boolean         |            Receives a boolean value that will determine if the completion value should be rendered to the user inside the chart.            |   true  |   false   |
+|           size          |           number          |           Specifies the overal size of the Donut Chart. We consider this number to calculate the chart radius and circunference.            |    -    |   true    |
+|       strokewidth       |           number          |                                  Specifies the width of the border you want to have on your donut chart.                                    |    -    |   true    |
+|    variablesClassName   |           string          |                                         Receives a custom class name for style/css customization.                                           |    -    |   false   |
 
 ## Getting Started
 
 ```javascript
-import React, { useState } from 'react';
+import React from 'react';
 import { DonutChart } from '@codelittinc/agnostic-design-system';
 
-const DonutChart = args => {
-  return <DonutChart {...args} />;
+const DonutChart = () => {
+  return (
+    <DonutChart
+      completion={50}
+      message="Lorem Ipsum"
+      size={200}
+      strokewidth={20}
+    />
+  );
 };
 
 export default DonutChart;
@@ -28,28 +36,29 @@ export default DonutChart;
 
 ## CSS Variables Available
 
-|        Property        |    Attribute     | State |
-| :--------------------: | :--------------: | :---: |
-| donutchart-full-circle |       fill       |       |
-| donutchart-full-circle |      stroke      |       |
-|  donutchart-indicator  |       fill       |       |
-|  donutchart-indicator  |      stroke      |       |
-|  donutchart-indicator  | stroke-dasharray |       |
-|  donutchart-indicator  |    transition    |       |
-|       donutchart       |      margin      |       |
-|       donutchart       |  border-radius   |       |
-|       donutchart       |     display      |       |
-|    donutchart-text     |   align-items    |       |
-|    donutchart-text     |      bottom      |       |
-|    donutchart-text     |     display      |       |
-|    donutchart-text     |  flex-direction  |       |
-|    donutchart-text     |       fill       |       |
-|    donutchart-text     |   font-family    |       |
-|    donutchart-text     | justify-content  |       |
-|    donutchart-text     |       left       |       |
-|    donutchart-text     |     position     |       |
-|    donutchart-text     |       top        |       |
-|    donutchart-text     |      width       |       |
-|  donutchart-text-val   |    font-size     |       |
-| donutchart-text-label  |    font-size     |       |
-| donutchart-text-label  |       gap        |       |
+|          Property           |    Attribute     | State |
+| :-------------------------: | :--------------: | :---: |
+|   donutchart-full-circle    |       fill       |       |
+|   donutchart-full-circle    |      stroke      |       |
+|    donutchart-indicator     |       fill       |       |
+|    donutchart-indicator     |      stroke      |       |
+|    donutchart-indicator     | stroke-dasharray |       |
+|    donutchart-indicator     |    transition    |       |
+|         donutchart          |      margin      |       |
+|         donutchart          |  border-radius   |       |
+|         donutchart          |     display      |       |
+|      donutchart-text        |   align-items    |       |
+|      donutchart-text        |      bottom      |       |
+|      donutchart-text        |     display      |       |
+|      donutchart-text        |  flex-direction  |       |
+|      donutchart-text        |       fill       |       |
+|      donutchart-text        |   font-family    |       |
+|      donutchart-text        | justify-content  |       |
+|      donutchart-text        |       left       |       |
+|      donutchart-text        |     position     |       |
+|      donutchart-text        |       top        |       |
+|      donutchart-text        |      width       |       |
+| donutchart-completion-value |    font-size     |       |
+|    donutchart-message       |    font-size     |       |
+|    donutchart-message       |   font-weight    |       |
+|    donutchart-message       |       gap        |       |

--- a/src/components/DonutChart/DonutChart.stories.tsx
+++ b/src/components/DonutChart/DonutChart.stories.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import DonutChart from '@/components/DonutChart';
 import { Meta } from '@storybook/react';
 import mdx from './DonutChart.stories.mdx';
-import classNames from 'classnames';
-
 import styles from './DonutChartTest.css';
 
 export default {
@@ -29,11 +27,33 @@ Default.args = {
   strokewidth: 10
 };
 
+export const WithMessageAsElement = Template.bind({});
+WithMessageAsElement.args = {
+  completion: 55,
+  message: <div>HTML Element Message</div>,
+  renderCompletionText: false,
+  size: 200,
+  strokewidth: 25
+};
+
+export const WithHoverTooltip = Template.bind({});
+WithHoverTooltip.args = {
+  completion: 55,
+  enableTooltip: true,
+  fullCircleTooltip: 'First Tooltip',
+  indicatorTooltip: 'SecondTooltip',
+  message: 'Completed',
+  renderCompletionValue: false,
+  size: 200,
+  strokewidth: 25,
+}
+
 export const CustomStyles = Template.bind({});
 CustomStyles.args = {
   completion: 55,
   message: 'Completed',
+  renderCompletionValue: false,
   size: 200,
-  strokewidth: 15,
-  variablesClassName: classNames(styles['custom-donut-chart'])
+  strokewidth: 25,
+  variablesClassName: styles['custom-donut-chart']
 };

--- a/src/components/DonutChart/DonutChartTest.css
+++ b/src/components/DonutChart/DonutChartTest.css
@@ -1,7 +1,9 @@
 .custom-donut-chart {
-  --donutchart-full-circle-stroke: pink;
-  --donutchart-indicator-stroke: red;
+  --donutchart-full-circle-stroke: var(--secondary-color-100);
+  --donutchart-indicator-stroke: var(--secondary-color-400);
   --donutchart-text-font-family: 'Nunito Sans';
-  --donutchart-text-val-font-size: 15px;
-  --donutchart-text-label-font-size: 15px;
+  --donutchart-completion-value-font-size: 15px;
+  --donutchart-message-color: var(--error-color);
+  --donutchart-message-font-size: 20px;
+  --donutchart-message-font-weight: 500;
 }

--- a/src/components/DonutChart/__tests__/__snapshots__/DonutChart.test.tsx.snap
+++ b/src/components/DonutChart/__tests__/__snapshots__/DonutChart.test.tsx.snap
@@ -8,11 +8,7 @@ exports[`DonutChart renders correctly 1`] = `
   strokewidth={10}
 >
   <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
+    className="wrapper"
   >
     <svg
       className="donutchart"
@@ -54,12 +50,12 @@ exports[`DonutChart renders correctly 1`] = `
       className="donutchart-text"
     >
       <span
-        className="donutchart-text-val"
+        className="donutchart-completion-value"
       >
         55
       </span>
       <span
-        className="donutchart-text-label"
+        className="donutchart-message"
       >
          
         Completed

--- a/src/components/DonutChart/index.tsx
+++ b/src/components/DonutChart/index.tsx
@@ -1,18 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from '@/components/DonutChart/DonutChart.css';
 import classnames from 'classnames';
 
 interface Props {
+  completion: number;
+  enableTooltip?: boolean;
+  fullCircleTooltip?: string | React.ReactNode;
+  iconForMessage?: React.ReactNode;
+  indicatorTooltip?: string | React.ReactNode;
+  message?: string | React.ReactNode;
+  renderCompletionValue?: boolean;
   size: number;
   strokewidth: number;
-  completion: number;
-  message?: string;
-  iconForMessage?: React.ReactNode;
   variablesClassName?: string;
 }
 
 const DonutChart = (props: Props) => {
-  const { size, strokewidth, completion, message, iconForMessage, variablesClassName } = props;
+  const {
+    completion,
+    enableTooltip,
+    fullCircleTooltip,
+    iconForMessage,
+    indicatorTooltip,
+    message,
+    renderCompletionValue = true,
+    size,
+    strokewidth,
+    variablesClassName
+  } = props;
+
+  const [showFullCircleTooltip, setShowFullCircleTooltip] = useState(true);
+  const [showIndicatorTooltip, setShowIndicatorTooltip] = useState(false);
 
   const halfsize = size * 0.5;
   const radius = halfsize - strokewidth * 0.5;
@@ -25,8 +43,20 @@ const DonutChart = (props: Props) => {
   const rotateval = 'rotate(-90 ' + halfsize + ',' + halfsize + ')';
 
   return (
-    <div style={{ position: 'relative' }}>
-      <svg width={size} height={size} className={classnames('donutchart', variablesClassName)}>
+    <div className={classnames(styles.wrapper, variablesClassName)}>
+      {showFullCircleTooltip && (
+        <div className={classnames(styles['tooltip-wrapper'], styles['full-circle-tooltip-wrapper'])}>
+          <div className={styles.tooltip}>{fullCircleTooltip}</div>
+        </div>
+      )}
+
+      {showIndicatorTooltip && (
+        <div className={classnames(styles['tooltip-wrapper'], styles['indicator-tooltip-wrapper'])}>
+          <div className={styles.test}>{indicatorTooltip}</div>
+        </div>
+      )}
+
+      <svg width={size} height={size} className={styles.donutchart}>
         <circle
           r={radius}
           cx={halfsize}
@@ -34,7 +64,11 @@ const DonutChart = (props: Props) => {
           transform={rotateval}
           style={trackstyle}
           className={styles['donutchart-full-circle']}
+          id="donutchart-full-circle"
+          onMouseOver={() => enableTooltip && setShowFullCircleTooltip(true)}
+          onMouseLeave={() => enableTooltip && setShowFullCircleTooltip(false)}
         />
+
         <circle
           r={radius}
           cx={halfsize}
@@ -42,13 +76,19 @@ const DonutChart = (props: Props) => {
           transform={rotateval}
           style={indicatorstyle}
           className={styles['donutchart-indicator']}
+          onMouseOver={() => enableTooltip && setShowIndicatorTooltip(true)}
+          onMouseLeave={() => enableTooltip && setShowIndicatorTooltip(false)}
         />
         <text className={styles['donutchart-text']} x={halfsize} y={halfsize} />
       </svg>
+
       <span className={styles['donutchart-text']}>
-        <span className={styles['donutchart-text-val']}>{completion}</span>
+        {renderCompletionValue && (
+          <span className={styles['donutchart-completion-value']}>{completion}</span>
+        )}
+
         {message && (
-          <span className={styles['donutchart-text-label']}>
+          <span className={styles['donutchart-message']}>
             {iconForMessage} {message}
           </span>
         )}


### PR DESCRIPTION
If applied, this pull request will Add customization to donut chart component

### Other minor changes:
 - updates documentation
 - renames text-val and text-label variables of the donut chart component to better match their abstractions
 - adds `renderCompletion` property
 - adds WithMessageAsElement storybook example
 - updates CustomStyled storybook example
