### PR TITLE
Add custom link option for breadcrumb items

### DIFF
--- a/src/components/BreadCrumb/BreadCrumb.stories.tsx
+++ b/src/components/BreadCrumb/BreadCrumb.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import BreadCrumb from '@/components/BreadCrumb';
 import mdx from './BreadCrumb.stories.mdx';
+import ArrowRight from '@/assets/images/icons/web/arrow-right.svg';
 
 export default {
   title: 'Components/BreadCrumb',
@@ -25,5 +26,15 @@ Default.args = {
     { title: 'Link Two', link: 'https://link-two.com' },
     { title: 'Link Three', link: 'https://link-three.com' },
     { title: 'Link Four', link: 'https://link-four.com' }
+  ]
+};
+
+export const Custom = Template.bind({});
+Custom.args = {
+  separator: <ArrowRight fill='#10193C' />,
+  items: [
+    { title: 'Link One', link: 'https://link-one.com' },
+    { title: 'Link Two', link: 'https://link-two.com' },
+    { customLink: <span style={{ color: 'red' }}>Link Three</span> }
   ]
 };

--- a/src/components/BreadCrumb/index.tsx
+++ b/src/components/BreadCrumb/index.tsx
@@ -3,18 +3,28 @@ import classnames from 'classnames';
 import styles from '@/components/BreadCrumb/BreadCrumb.css';
 
 type Item = {
-  title: string;
-  link: string;
+  title?: string;
+  link?: string;
+  customLink?: React.ReactNode;
 };
 
 interface Props {
   items: Item[];
-  separator?: string;
+  separator?: string | React.ReactNode;
   variablesClassName?: string;
 }
 
 const BreadCrumb: React.FC<Props> = props => {
   const { items, separator, variablesClassName } = props;
+
+  const getLink = ({ title, link, customLink }: Item) => {
+    if (customLink) return customLink;
+    return (
+      <a href={link} className={styles['breadcrumb-link']}>
+        {title}
+      </a>
+    );
+  };
 
   return (
     <div className={classnames(variablesClassName, styles.breadcrumb)}>
@@ -22,9 +32,7 @@ const BreadCrumb: React.FC<Props> = props => {
         return (
           <div key={key} className={styles['breadcrumb-list-item']}>
             <span className={styles['breadcrumb-separator']}>{separator}</span>
-            <a href={item.link} className={styles['breadcrumb-link']}>
-              {item.title}
-            </a>
+            {getLink(item)}
           </div>
         );
       })}


### PR DESCRIPTION
If applied, this pull request will Add custom link option for breadcrumb items

- The Item accepts a custom Link component that is used instead of the regular link
- Separator now accepts a component instead of just a string

### Implementation Screenshot or GIF
![Screen Shot 2022-09-12 at 10 27 39](https://user-images.githubusercontent.com/1226583/189666527-a9e6e009-eac2-4851-8b50-9e3d13067f89.png)